### PR TITLE
Ensure Pulse is rebuilt when updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,11 @@ sudo apt install opam
 
 ## Building C2Pulse 
 
-### Build Custom LLVM 
-```bash
-git clone --recurse-submodules git@github.com:angelica-moreira/CodeShield.git
-cd CodeShield/external_tools/llvm-project
-mkdir build 
-cd build
-cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DLLVM_PARALLEL_LINK_JOBS=2 -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_LLD=ON -DCMAKE_LINKER=lld -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" -DLLVM_TARGETS_TO_BUILD="X86" ../llvm
-ninja -j $(nproc)
-```
----
-
-## Build C2Pulse from build script
 ```bash
 ./build.sh
 ```
 
-Use **-DCMAKE_BUILD_TYPE=Release** if you are not a developer for faster build and faster
+Set the environment variable `C2PULSE_BUILD_TYPE=Release` if you are not a developer for faster build and faster
 binary executable. This will produce a binary executable in the build/bin directory of the LLVM build. 
 The binary will be called `c2pulse`. You can run the tool as follows:
 
@@ -116,7 +104,7 @@ The plugin rewrites it to a Pulse program stored in file Swap.fst.
 In general, it emits pulse code for the file in a file called
 Filename.fst (capitalizes the first letter)
 
-```pulse
+```fstar
 module Swap
 
 #lang-pulse

--- a/build.sh
+++ b/build.sh
@@ -9,33 +9,19 @@ CLANG_BIN="$LLVM_BUILD_DIR/bin"
 
 #Ensure that LLVM is build first.
 if [[ ! -x "$CLANG_BIN/clang++" ]]; then
-  echo "clang++ not found in $CLANG_BIN!" >&2
-  echo "Please build LLVM first by running ./build_clang.sh" >&2
-  exit 1
+  echo "clang++ not found in $CLANG_BIN!"
+  echo "Building LLVM first"
+  $HERE/build_clang.sh
 fi
 
-if ! [[ -x "$HERE/external/FStar/bin/fstar.exe" ]]; then
-  echo "Building F*"
-  make -C $HERE/external/FStar -j$(nproc) ADMIT=1
-fi
+echo "Building F*"
+make -C $HERE/external/FStar -j$(nproc) ADMIT=1
 
-if ! [[ -x "$HERE/external/pulse/out/lib/pulse/pulse.cmxs" ]]; then
-  echo "Building Pulse"
-  make -C $HERE/external/pulse -j$(nproc) ADMIT=1 FSTAR_EXE=$(realpath $HERE/external/FStar/bin/fstar.exe)
-fi
+echo "Building Pulse"
+make -C $HERE/external/pulse -j$(nproc) ADMIT=1 FSTAR_EXE=$(realpath $HERE/external/FStar/bin/fstar.exe)
 
-
-if ! [[ -x "./include/pulse/_cache/Pulse.Lib.C.Int32.fst.checked" ]]; then
-  echo "Building Pulse.Lib.C libraries"
-  make -C $HERE/include/pulse -j$(nproc)
-fi
-
-if [[ -x "$CLANG_BIN/c2pulse" ]]; then
-  echo "C2Pulse exists in $CLANG_BIN!"
-  echo "Rebuilding existing project!"
-  ninja -C $LLVM_BUILD_DIR -j $(nproc)
-  exit 0
-fi
+echo "Building Pulse.Lib.C libraries"
+make -C $HERE/include/pulse -j$(nproc)
 
 if [[ ! -x "$LLVM_DIR/clang/tools/c2pulse" ]]; then
 	ln -s "$(pwd)" $LLVM_DIR/clang/tools/c2pulse


### PR DESCRIPTION
This changes the build script to always rebuild F*, Pulse, and the c2pulse Pulse library.  Otherwise it's easy to forget rebuilding them after a git pull.

This adds about 1.8s to a build where nothing changed; usually the C++ compilation step completely dwarfs this so this is not a big downside.  Most of the 1.8s is spent in Pulse, we can probably make that faster upstream.