### PR TITLE
Require shift RHS to be uint32_t, allow any unsigned int LHS

### DIFF
--- a/src/pass/check.rs
+++ b/src/pass/check.rs
@@ -259,9 +259,22 @@ impl<'a> Checker<'a> {
                         | BinOp::Sub
                         | BinOp::BitAnd
                         | BinOp::BitOr
-                        | BinOp::BitXor
-                        | BinOp::Shl
-                        | BinOp::Shr => check_eq(self),
+                        | BinOp::BitXor => check_eq(self),
+                        BinOp::Shl | BinOp::Shr => {
+                            let u32_ty: MaybeRc<Type> =
+                                TypeT::Int { signed: false, width: 32 }
+                                    .with_loc(rhs.loc.clone())
+                                    .into();
+                            if !env.vtype_eq(rhs_ty.clone().into(), u32_ty) {
+                                self.report(
+                                    format!(
+                                        "shift amount must be uint32_t, not {}",
+                                        rhs_ty
+                                    ),
+                                    &rval.loc,
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/src/pass/check.rs
+++ b/src/pass/check.rs
@@ -280,16 +280,15 @@ impl<'a> Checker<'a> {
                         | BinOp::BitOr
                         | BinOp::BitXor => check_eq(self),
                         BinOp::Shl | BinOp::Shr => {
-                            let u32_ty: MaybeRc<Type> =
-                                TypeT::Int { signed: false, width: 32 }
-                                    .with_loc(rhs.loc.clone())
-                                    .into();
+                            let u32_ty: MaybeRc<Type> = TypeT::Int {
+                                signed: false,
+                                width: 32,
+                            }
+                            .with_loc(rhs.loc.clone())
+                            .into();
                             if !env.vtype_eq(rhs_ty.clone().into(), u32_ty) {
                                 self.report(
-                                    format!(
-                                        "shift amount must be uint32_t, not {}",
-                                        rhs_ty
-                                    ),
+                                    format!("shift amount must be uint32_t, not {}", rhs_ty),
                                     &rval.loc,
                                 )
                             }

--- a/src/pass/elab.rs
+++ b/src/pass/elab.rs
@@ -266,10 +266,12 @@ impl<'a> Elaborator<'a> {
                         }
                     }
                     BinOp::Shl | BinOp::Shr => {
-                        let u32_ty: MaybeRc<Type> =
-                            TypeT::Int { signed: false, width: 32 }
-                                .with_loc(rhs.loc.clone())
-                                .into();
+                        let u32_ty: MaybeRc<Type> = TypeT::Int {
+                            signed: false,
+                            width: 32,
+                        }
+                        .with_loc(rhs.loc.clone())
+                        .into();
                         if !env.vtype_eq(rhs_ty, u32_ty.clone()) {
                             cast_to(rhs, u32_ty.to_rc())
                         }

--- a/src/pass/elab.rs
+++ b/src/pass/elab.rs
@@ -237,9 +237,7 @@ impl<'a> Elaborator<'a> {
                     | BinOp::Implies
                     | BinOp::BitAnd
                     | BinOp::BitOr
-                    | BinOp::BitXor
-                    | BinOp::Shl
-                    | BinOp::Shr => {
+                    | BinOp::BitXor => {
                         if let Some(meet_type) = env.meet_type(lhs_ty.clone(), rhs_ty.clone()) {
                             if !env.vtype_eq(lhs_ty, meet_type.clone()) {
                                 cast_to(lhs, meet_type.clone().to_rc())
@@ -255,6 +253,15 @@ impl<'a> Elaborator<'a> {
                                 ),
                                 &rval.loc,
                             );
+                        }
+                    }
+                    BinOp::Shl | BinOp::Shr => {
+                        let u32_ty: MaybeRc<Type> =
+                            TypeT::Int { signed: false, width: 32 }
+                                .with_loc(rhs.loc.clone())
+                                .into();
+                        if !env.vtype_eq(rhs_ty, u32_ty.clone()) {
+                            cast_to(rhs, u32_ty.to_rc())
                         }
                     }
                 }

--- a/test/bitops.c
+++ b/test/bitops.c
@@ -36,3 +36,15 @@ uint32_t test_shr(uint32_t a, uint32_t b)
 {
     return a >> b;
 }
+
+uint64_t test_shl64(uint64_t a, uint32_t b)
+    _requires(b < 64u)
+{
+    return a << b;
+}
+
+uint64_t test_shr64(uint64_t a, uint32_t b)
+    _requires(b < 64u)
+{
+    return a >> b;
+}


### PR DESCRIPTION
In F*/Pulse, shift operations (shift_left/shift_right) expect the shift amount to be UInt32.t regardless of the value type. Update the typechecker (elab) to cast the RHS to uint32_t instead of unifying both operands, and update the post-elab checker to validate this invariant.

Add uint64_t shift tests (test_shl64, test_shr64) to test/bitops.c.

Fixes #74.