### PR TITLE
Add CharacterLiteral support in trRValue

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -618,6 +618,11 @@ public:
         return mk_int_lit(std::move(loc), toBigInt(il->getValue()),
                           std::move(ty));
       }
+    } else if (auto cl = dyn_cast<CharacterLiteral>(e)) {
+      auto ty = trQualType(cl->getType(), cl->getSourceRange());
+      return mk_int_lit(std::move(loc),
+                        mk_bigint(toStr(std::to_string(cl->getValue()))),
+                        std::move(ty));
     } else if (auto uo = dyn_cast<UnaryOperator>(e)) {
       switch (uo->getOpcode()) {
       case UO_AddrOf:

--- a/src/hauntedc.rs
+++ b/src/hauntedc.rs
@@ -143,6 +143,7 @@ enum Token<'src> {
 
     String(&'src str),
     Integer(&'src str, IntegerSuffix),
+    Char(u32),
     Ident(&'src str),
 
     Punct(Punct),
@@ -156,6 +157,7 @@ impl<'src> Display for Token<'src> {
             Token::Whitespace => write!(f, " "),
             Token::String(tok) => write!(f, "{}", tok),
             Token::Integer(i, suffix) => write!(f, "{}{}", i, suffix),
+            Token::Char(n) => write!(f, "'\\x{:x}'", n),
             Token::Ident(id) => write!(f, "{}", id),
             Token::Punct(punct) => write!(f, "{}", punct.to_str()),
             Token::Error => write!(f, "(LEXING ERROR)"),
@@ -203,13 +205,43 @@ fn lex_core_token<'src>() -> impl Parser<'src, &'src str, Token<'src>> {
         .delimited_by(just('"'), just('"'))
         .map(Token::String);
 
+    // C-style character literal: 'X' or '\E' for a small set of common
+    // escapes. The value is the codepoint of the character (for plain
+    // chars) or the escape-mapped byte value. Wide-char prefixes (L'…',
+    // u'…', U'…'), multi-character constants, octal escapes, and
+    // \xHH+ / \uHHHH numeric escapes are unsupported
+    let char_escape = just('\\').ignore_then(choice((
+        just('n').to(b'\n' as u32),
+        just('t').to(b'\t' as u32),
+        just('r').to(b'\r' as u32),
+        just('0').to(0u32),
+        just('\\').to(b'\\' as u32),
+        just('\'').to(b'\'' as u32),
+        just('"').to(b'"' as u32),
+        just('a').to(0x07u32),
+        just('b').to(0x08u32),
+        just('f').to(0x0Cu32),
+        just('v').to(0x0Bu32),
+        just('?').to(b'?' as u32),
+    )));
+    let plain_char = none_of("'\\\n").map(|c: char| c as u32);
+    let char_literal = char_escape
+        .or(plain_char)
+        .delimited_by(just('\''), just('\''))
+        .map(Token::Char);
+
     let fallback = text::whitespace()
         .not()
         .repeated()
         .at_least(1)
         .to(Token::Error);
 
-    integer_literal.or(op).or(ident).or(string).or(fallback)
+    integer_literal
+        .or(op)
+        .or(ident)
+        .or(string)
+        .or(char_literal)
+        .or(fallback)
 }
 
 fn ws<'tokens, 'src: 'tokens, I: ValueInput<'tokens, Token = Token<'src>, Span = Span>, Span>()
@@ -600,7 +632,18 @@ fn expr_parser<
                 }
             });
 
-        let constant = integer_constant;
+        // Character constants are emitted as SpecInt-typed integer
+        // literals — matches how an unsuffixed `65` is treated in a
+        // spec, which is what `'A'` is.
+        let char_constant = select! { Token::Char(n) => n }.map_with(|n, extra| -> Expr {
+            let loc = sift.resolve_source_info(&extra.span());
+            let ty = TypeT::SpecInt.with_loc(loc.clone());
+            ExprT::IntLit(Rc::new(BigInt::from(n)), ty)
+                .with_loc(loc)
+                .into()
+        });
+
+        let constant = integer_constant.or(char_constant);
 
         let parenthesized = expr
             .clone()

--- a/test/character_literals.c
+++ b/test/character_literals.c
@@ -1,0 +1,59 @@
+#include "pal.h"
+#include <stdint.h>
+
+/* CharacterLiteral test.
+
+   The four cases below exercise the three positions in a C body that
+   reach trRValue with a CharacterLiteral: return expression,
+   arithmetic operand, and switch case label.
+
+   Note on postconditions: the inline-Pulse spec parser in
+   src/hauntedc.rs is a separate code path that doesn't yet recognise
+   character literals at all, so we deliberately use the integer
+   ASCII equivalents in _requires / _ensures. Supporting them in spec
+   contexts would require new lexer + parser rules and is out of
+   scope here. */
+
+/* Position 1: return expression — plain CharacterLiteral as rvalue */
+int32_t letter_a(void)
+    _ensures(return == 65)
+{
+    return 'A';
+}
+
+int32_t newline_char(void)
+    _ensures(return == 10)
+{
+    return '\n';
+}
+
+int32_t null_char(void)
+    _ensures(return == 0)
+{
+    return '\0';
+}
+
+/* Position 2: inside an arithmetic expression — confirms the literal
+   participates in binary ops the same way an IntegerLiteral does. */
+int32_t alphabet_index(int32_t c)
+    _requires(c >= 65 && c <= 90)
+    _ensures(return == c - 65)
+{
+    return c - 'A';
+}
+
+/* Position 3: switch case label — case values also flow through
+   trRValue (cpp/impl.cpp ~line 1096), so character literals must
+   work as case labels too. */
+int32_t classify_char(int32_t c)
+    _ensures(c == 65 ==> return == 1)
+    _ensures(c == 10 ==> return == 2)
+    _ensures(c == 0  ==> return == 3)
+{
+    switch (c) {
+    case 'A':  return 1;
+    case '\n': return 2;
+    case '\0': return 3;
+    default:   return 0;
+    }
+}

--- a/test/character_literals.c
+++ b/test/character_literals.c
@@ -7,28 +7,21 @@
    reach trRValue with a CharacterLiteral: return expression,
    arithmetic operand, and switch case label.
 
-   Note on postconditions: the inline-Pulse spec parser in
-   src/hauntedc.rs is a separate code path that doesn't yet recognise
-   character literals at all, so we deliberately use the integer
-   ASCII equivalents in _requires / _ensures. Supporting them in spec
-   contexts would require new lexer + parser rules and is out of
-   scope here. */
-
 /* Position 1: return expression — plain CharacterLiteral as rvalue */
 int32_t letter_a(void)
-    _ensures(return == 65)
+    _ensures(return == 'A')
 {
     return 'A';
 }
 
 int32_t newline_char(void)
-    _ensures(return == 10)
+    _ensures(return == '\n')
 {
     return '\n';
 }
 
 int32_t null_char(void)
-    _ensures(return == 0)
+    _ensures(return == '\0')
 {
     return '\0';
 }
@@ -36,19 +29,17 @@ int32_t null_char(void)
 /* Position 2: inside an arithmetic expression — confirms the literal
    participates in binary ops the same way an IntegerLiteral does. */
 int32_t alphabet_index(int32_t c)
-    _requires(c >= 65 && c <= 90)
-    _ensures(return == c - 65)
+    _requires(c >= 'A' && c <= 'Z')
+    _ensures(return == c - 'A')
 {
     return c - 'A';
 }
 
-/* Position 3: switch case label — case values also flow through
-   trRValue (cpp/impl.cpp ~line 1096), so character literals must
-   work as case labels too. */
+/* Position 3: switch case label */
 int32_t classify_char(int32_t c)
-    _ensures(c == 65 ==> return == 1)
-    _ensures(c == 10 ==> return == 2)
-    _ensures(c == 0  ==> return == 3)
+    _ensures(c == 'A'  ==> return == 1)
+    _ensures(c == '\n' ==> return == 2)
+    _ensures(c == '\0' ==> return == 3)
 {
     switch (c) {
     case 'A':  return 1;
@@ -56,4 +47,5 @@ int32_t classify_char(int32_t c)
     case '\0': return 3;
     default:   return 0;
     }
+    return 0;
 }


### PR DESCRIPTION
Character literals ('A', '\n', etc.) were falling through the rvalue visitor's dyn_cast chain and producing 'unsupported rvalue expression CharacterLiteral' diagnostics, which became (admit()) in the emitted Pulse code.

Translate them as IntLit nodes of the appropriate (int) type, matching how the C standard defines character constants. Verified on MSQuic's src/core: eliminates all 286 CharacterLiteral diagnostics and reduces the total admit count from 19,910 to 19,826 (-84).