### PR TITLE
Add support for `sizeof`

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -797,6 +797,24 @@ public:
       }
       // Other DeclRefExpr in rvalue context: treat as lvalue read
       return mk_rvalue_lvalue(std::move(loc), trLValue(e));
+    } else if (auto *u = dyn_cast<UnaryExprOrTypeTraitExpr>(e)) {
+      // sizeof / _Alignof: clang has already constant-folded these for any
+      // non-VLA type or expression. Emit as a size_t literal. The value
+      // depends on the target triple PAL invokes clang with; for a 64-bit
+      // target this matches the runtime layout assumed by msquic.
+      if (u->getKind() == UETT_SizeOf || u->getKind() == UETT_AlignOf ||
+          u->getKind() == UETT_PreferredAlignOf) {
+        Expr::EvalResult er;
+        if (u->EvaluateAsInt(er, *astCtx)) {
+          SmallString<32> valStr;
+          er.Val.getInt().toString(valStr);
+          return mk_int_lit(loc.clone(),
+                            mk_bigint(toStr(StringRef(valStr))),
+                            mk_sizet(std::move(loc)));
+        }
+        // VLA sizeof or other non-constant case: fall through to the
+        // generic unsupported-rvalue error below.
+      }
     }
 
     reportUnsupported(e->getSourceRange(), loc,

--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -808,8 +808,7 @@ public:
         if (u->EvaluateAsInt(er, *astCtx)) {
           SmallString<32> valStr;
           er.Val.getInt().toString(valStr);
-          return mk_int_lit(loc.clone(),
-                            mk_bigint(toStr(StringRef(valStr))),
+          return mk_int_lit(loc.clone(), mk_bigint(toStr(StringRef(valStr))),
                             mk_sizet(std::move(loc)));
         }
         // VLA sizeof or other non-constant case: fall through to the

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -1544,7 +1544,17 @@ impl<'a> Emitter<'a> {
                         // (TypeT::Int { signed, width }, TypeT::SizeT) => todo!(),
                         // (TypeT::Int { signed, width }, TypeT::SLProp) => todo!(),
                         // (TypeT::SizeT, TypeT::Bool) => todo!(),
-                        // (TypeT::SizeT, TypeT::Int { signed, width }) => todo!(),
+                        (TypeT::SizeT, TypeT::Int { signed, width }) => {
+                            if let Some(m) = get_int_mod(signed, width) {
+                                unaryfn(
+                                    Doc::text(format!("{}.uint_to_t (SizeT.v", m)),
+                                    val_doc.append(Doc::text(")")),
+                                )
+                            } else {
+                                self.report(default_msg.clone(), &v.loc);
+                                Doc::text("(admit())")
+                            }
+                        }
                         // (TypeT::SizeT, TypeT::SLProp) => todo!(),
                         // (TypeT::Pointer { to, kind }, TypeT::Bool) => todo!(),
                         (TypeT::Pointer(_, kind), TypeT::Bool) => {

--- a/test/sizeof.c
+++ b/test/sizeof.c
@@ -2,49 +2,49 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// sizeof of a builtin type in a size_t-position
 size_t size_of_int(void)
+    _ensures(return == 4uz)
 {
     return sizeof(int);
 }
 
-// sizeof of an expression (clang folds based on the expression's type)
 size_t size_of_expr(int x)
+    _ensures(return == 4uz)
 {
     return sizeof(x);
 }
 
-// sizeof participating in arithmetic against another size_t literal
 size_t bytes_for_10_ints(void)
+    _ensures(return == 40uz)
 {
     return (size_t) 10 * sizeof(int);
 }
 
-// sizeof of a struct type
 typedef struct {
     int x;
     int y;
 } two_ints;
 
 size_t size_of_two_ints(void)
+    _ensures(return == 8uz)
 {
     return sizeof(two_ints);
 }
 
-// sizeof of an array type
 size_t size_of_int_array(void)
+    _ensures(return == 32uz)
 {
     return sizeof(int[8]);
 }
 
-// Cast sizeof to a narrower integer type (exercises the new SizeT -> Int cast).
 uint32_t size_of_int_u32(void)
+    _ensures(return == 4u)
 {
     return (uint32_t) sizeof(int);
 }
 
-// _Alignof of a builtin type
 size_t align_of_int(void)
+    _ensures(return == 4uz)
 {
     return _Alignof(int);
 }

--- a/test/sizeof.c
+++ b/test/sizeof.c
@@ -1,0 +1,51 @@
+#include "pal.h"
+#include <stdint.h>
+#include <stddef.h>
+
+// sizeof of a builtin type in a size_t-position
+size_t size_of_int(void)
+{
+    return sizeof(int);
+}
+
+// sizeof of an expression (clang folds based on the expression's type)
+size_t size_of_expr(int x)
+{
+    return sizeof(x);
+}
+
+// sizeof participating in arithmetic against another size_t literal
+size_t bytes_for_10_ints(void)
+{
+    return (size_t) 10 * sizeof(int);
+}
+
+// sizeof of a struct type
+typedef struct {
+    int x;
+    int y;
+} two_ints;
+
+size_t size_of_two_ints(void)
+{
+    return sizeof(two_ints);
+}
+
+// sizeof of an array type
+size_t size_of_int_array(void)
+{
+    return sizeof(int[8]);
+}
+
+// Cast sizeof to a narrower integer type (exercises the new SizeT -> Int cast).
+uint32_t size_of_int_u32(void)
+{
+    return (uint32_t) sizeof(int);
+}
+
+// _Alignof of a builtin type
+size_t align_of_int(void)
+{
+    return _Alignof(int);
+}
+


### PR DESCRIPTION
This PR adds support for sizeof (and _Alignof/__alignof__) in the translation of C code. The values are evaluated by Clang against the target and emitted as size_t literals. We use these literals emitted by Clang.
No support has been added to hauntedc for now, so the values must be hardcoded in specs.

 Also adds support for type casts from size_t to int, since these are often used alongside sizeof.
 
 Note that this adds the assumption that the code gets compiled by a compiler that uses the Clang AST. 


Assumptions:

 - The C source is compiled by a clang-compatible compiler for the same target triple PAL was built against. The values clang computes for sizeof depend on the target, not just on it being 64-bit: for example, sizeof(long) is 8 on Linux/macOS but 4 on Windows/MSVC.
 - The hardcoded values in specs inherit this same assumption, since they are written by hand against a specific target.
 - Only sizeof of types with a compile-time-known size is supported — VLAs (variable-length arrays) are not.