### PR TITLE
Translate sizeof/_Alignof to opaque polymorphic c_sizeof/c_alignof

### DIFF
--- a/cpp/iface.zng
+++ b/cpp/iface.zng
@@ -273,6 +273,8 @@ mod crate::clang {
     fn mk_cond(Rc<SourceInfo>, Rc<Expr>, Rc<Expr>, Rc<Expr>) -> Rc<Expr>;
     fn mk_live(Rc<SourceInfo>, Rc<Expr>) -> Rc<Expr>;
     fn mk_assign_expr(Rc<SourceInfo>, Rc<Expr>, Rc<Expr>) -> Rc<Expr>;
+    fn mk_sizeof(Rc<SourceInfo>, Rc<Type>) -> Rc<Expr>;
+    fn mk_alignof(Rc<SourceInfo>, Rc<Type>) -> Rc<Expr>;
 
     fn mk_lvalue_var(Rc<SourceInfo>, Rc<Ident>) -> Rc<Expr>;
     fn mk_lvalue_member(Rc<SourceInfo>, Rc<Expr>, Rc<Ident>) -> Rc<Expr>;

--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -797,6 +797,26 @@ public:
       }
       // Other DeclRefExpr in rvalue context: treat as lvalue read
       return mk_rvalue_lvalue(std::move(loc), trLValue(e));
+    } else if (auto *u = dyn_cast<UnaryExprOrTypeTraitExpr>(e)) {
+      auto kind = u->getKind();
+      if (kind == UETT_SizeOf || kind == UETT_AlignOf ||
+          kind == UETT_PreferredAlignOf) {
+        auto argTy = u->getTypeOfArgument();
+        if (argTy->isIncompleteType() || argTy->isDependentType() ||
+            argTy->isVariableArrayType()) {
+          reportUnsupported(
+              e->getSourceRange(), loc,
+              "sizeof/_Alignof on incomplete, dependent, or VLA type ", "");
+          return mk_rvalue_err(std::move(loc),
+                               trQualType(e->getType(), e->getSourceRange()));
+        }
+        auto ty = trQualType(argTy, e->getSourceRange());
+        if (kind == UETT_SizeOf) {
+          return mk_sizeof(std::move(loc), std::move(ty));
+        } else {
+          return mk_alignof(std::move(loc), std::move(ty));
+        }
+      }
     }
 
     reportUnsupported(e->getSourceRange(), loc,

--- a/pulse/Pulse.Lib.C.Sizeof.fsti
+++ b/pulse/Pulse.Lib.C.Sizeof.fsti
@@ -1,0 +1,22 @@
+module Pulse.Lib.C.Sizeof
+
+open FStar.SizeT
+
+/// Opaque byte-size of an arbitrary F* type, intended to be used as the
+/// translation of `sizeof(T)` from C. The function commits to no
+/// particular value — only that whatever it returns is strictly positive.
+val c_sizeof (a: Type u#a) : t
+
+/// Opaque alignment-in-bytes of an arbitrary F* type, intended to be used
+/// as the translation of `_Alignof(T)` from C.
+val c_alignof (a: Type u#a) : t
+
+/// Sizes are strictly positive on any conforming C implementation.
+val c_sizeof_pos (a: Type u#a)
+  : Lemma (v (c_sizeof a) > 0)
+    [SMTPat (v (c_sizeof a))]
+
+/// Alignments are strictly positive on any conforming C implementation.
+val c_alignof_pos (a: Type u#a)
+  : Lemma (v (c_alignof a) > 0)
+    [SMTPat (v (c_alignof a))]

--- a/pulse/Pulse.Lib.C.fsti
+++ b/pulse/Pulse.Lib.C.fsti
@@ -9,6 +9,7 @@ include Pulse.Class.PtsTo
 include FStar.Int.Cast
 include Pulse.Lib.C.Casts
 include Pulse.Lib.C.UnaryOps
+include Pulse.Lib.C.Sizeof
 include Pulse.Lib.WithPure
 open Pulse.Lib.Core
 let _Bool = bool

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -680,6 +680,12 @@ fn mk_live(loc: Rc<SourceInfo>, val: Rc<Expr>) -> Rc<Expr> {
 fn mk_assign_expr(loc: Rc<SourceInfo>, lhs: Rc<Expr>, rhs: Rc<Expr>) -> Rc<Expr> {
     mk_ast(loc, ExprT::AssignExpr(lhs, rhs))
 }
+fn mk_sizeof(loc: Rc<SourceInfo>, ty: Rc<Type>) -> Rc<Expr> {
+    mk_ast(loc, ExprT::SizeOf(ty))
+}
+fn mk_alignof(loc: Rc<SourceInfo>, ty: Rc<Type>) -> Rc<Expr> {
+    mk_ast(loc, ExprT::AlignOf(ty))
+}
 
 pub struct StructInitBuilder {
     loc: Rc<SourceInfo>,

--- a/src/env.rs
+++ b/src/env.rs
@@ -358,6 +358,7 @@ impl Env {
             },
             ExprT::Cast(_, ty) => Ok(ty.clone().into()),
             ExprT::Error(ty) => Ok(ty.clone().into()),
+            ExprT::SizeOf(_) | ExprT::AlignOf(_) => Ok(expr.reuse_loc(TypeT::SizeT).into()),
             ExprT::Malloc(ty) | ExprT::Calloc(ty) => Ok(expr
                 .reuse_loc(TypeT::Pointer(ty.clone(), PointerKind::Ref))
                 .into()),

--- a/src/hauntedc.rs
+++ b/src/hauntedc.rs
@@ -686,6 +686,37 @@ fn expr_parser<
                         .with_loc(loc)
                         .into()
                 }),
+            // sizeof(<type>) / sizeof(<type>[N]) and _Alignof(<type>)
+            select! {
+                Token::Ident("sizeof") => true,
+                Token::Ident("_Alignof") => false,
+                Token::Ident("__alignof__") => false,
+            }
+            .padded_by(ws())
+            .then(
+                type_name
+                    .clone()
+                    .then(
+                        select! { Token::Integer(_, _) => () }
+                            .delimited_by(punct(Punct::LBracket), punct(Punct::RBracket))
+                            .or_not(),
+                    )
+                    .delimited_by(punct(Punct::LParen), punct(Punct::RParen)),
+            )
+            .map_with(|(is_sizeof, (ty, arr_opt)), extra| -> Expr {
+                let loc = sift.resolve_source_info(&extra.span());
+                let inner_ty = match arr_opt {
+                    None => ty,
+                    Some(()) => TypeT::Pointer(ty, PointerKind::Array).with_loc(loc.clone()),
+                };
+                let expr_t = if is_sizeof {
+                    ExprT::SizeOf(inner_ty)
+                } else {
+                    ExprT::AlignOf(inner_ty)
+                };
+                expr_t.with_loc(loc).into()
+            })
+            .boxed(),
             ident
                 .clone() // TODO: function should be postfix_expression
                 .then(

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -304,6 +304,11 @@ pub enum ExprT {
     /// Assignment expression: assigns rhs to lhs, evaluates to rhs.
     /// Lowered to Assign statement + value in elab pass.
     AssignExpr(Rc<Expr>, Rc<Expr>),
+    /// `sizeof(T)` — translated to an opaque `c_sizeof T` call where `T`
+    /// is the F* type PAL uses to represent the C type being measured.
+    SizeOf(Rc<Type>),
+    /// `_Alignof(T)` / `__alignof__(T)` — translated to `c_alignof T`.
+    AlignOf(Rc<Type>),
     Error(Rc<Type>),
 }
 

--- a/src/ir/pretty.rs
+++ b/src/ir/pretty.rs
@@ -343,6 +343,8 @@ impl PrettyIR for ExprT {
                 .append(")")
                 .nest(2)
                 .group(),
+            ExprT::SizeOf(ty) => RcDoc::text("sizeof(").append(ty.to_doc()).append(")"),
+            ExprT::AlignOf(ty) => RcDoc::text("_Alignof(").append(ty.to_doc()).append(")"),
         }
     }
 }

--- a/src/pass/check.rs
+++ b/src/pass/check.rs
@@ -447,6 +447,7 @@ impl<'a> Checker<'a> {
                 self.check_rvalue(env, lhs);
                 self.check_rvalue(env, rhs);
             }
+            ExprT::SizeOf(ty) | ExprT::AlignOf(ty) => self.check_type(env, ty),
             ExprT::Error(ty) => self.check_type(env, ty),
         }
     }

--- a/src/pass/elab.rs
+++ b/src/pass/elab.rs
@@ -247,6 +247,7 @@ impl<'a> Elaborator<'a> {
                 // TODO: check that actual_ty can be casted to ty
             }
             ExprT::Error(ty) => self.elab_type(env, Rc::make_mut(ty)),
+            ExprT::SizeOf(ty) | ExprT::AlignOf(ty) => self.elab_type(env, Rc::make_mut(ty)),
             ExprT::Malloc(ty) | ExprT::Calloc(ty) => self.elab_type(env, Rc::make_mut(ty)),
             ExprT::MallocArray(ty, count) | ExprT::CallocArray(ty, count) => {
                 self.elab_type(env, Rc::make_mut(ty));

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -571,6 +571,7 @@ impl<'a> Emitter<'a> {
                 self.subst_this_rvalue(env, Rc::make_mut(lhs), this);
                 self.subst_this_rvalue(env, Rc::make_mut(rhs), this);
             }
+            ExprT::SizeOf(_) | ExprT::AlignOf(_) => {}
         }
     }
 
@@ -2018,6 +2019,14 @@ impl<'a> Emitter<'a> {
                     );
                     Doc::text("(admit())")
                 }
+                ExprT::SizeOf(ty) => unaryfn(
+                    Doc::text("Pulse.Lib.C.Sizeof.c_sizeof"),
+                    self.emit_type(env, ty),
+                ),
+                ExprT::AlignOf(ty) => unaryfn(
+                    Doc::text("Pulse.Lib.C.Sizeof.c_alignof"),
+                    self.emit_type(env, ty),
+                ),
             }
         })
     }

--- a/src/pass/prune.rs
+++ b/src/pass/prune.rs
@@ -147,6 +147,7 @@ fn scan_expr(deps: &mut HashSet<DeclName>, rv: &Expr) {
             scan_type(deps, ty);
         }
         ExprT::Error(ty) => scan_type(deps, ty),
+        ExprT::SizeOf(ty) | ExprT::AlignOf(ty) => scan_type(deps, ty),
         ExprT::Malloc(ty) | ExprT::Calloc(ty) => scan_type(deps, ty),
         ExprT::MallocArray(ty, count) | ExprT::CallocArray(ty, count) => {
             scan_type(deps, ty);

--- a/test/sizeof.c
+++ b/test/sizeof.c
@@ -1,0 +1,38 @@
+#include "pal.h"
+#include <stdint.h>
+#include <stddef.h>
+
+size_t size_of_int(void)
+    _ensures(return == sizeof(int))
+{
+    return sizeof(int);
+}
+
+size_t size_of_expr(int x)
+    _ensures(return == sizeof(int))
+{
+    return sizeof(x);
+}
+
+typedef struct {
+    int x;
+    int y;
+} two_ints;
+
+size_t size_of_two_ints(void)
+    _ensures(return == sizeof(two_ints))
+{
+    return sizeof(two_ints);
+}
+
+size_t size_of_int_array(void)
+    _ensures(return == sizeof(int[8]))
+{
+    return sizeof(int[8]);
+}
+
+size_t align_of_int(void)
+    _ensures(return == _Alignof(int))
+{
+    return _Alignof(int);
+}


### PR DESCRIPTION
Replaces the more elaborate reified-c_type approach with a single polymorphic Pulse declaration:

    val c_sizeof  (a: Type u#a) : SizeT.t
    val c_alignof (a: Type u#a) : SizeT.t

and one axiom each saying the result is strictly positive.

C 'sizeof(T)' and '_Alignof(T)' are now translated by:
  - reusing the existing trQualType to obtain PAL's IR type for T,
  - wrapping it in a new ExprT::SizeOf / ExprT::AlignOf IR node,
  - emitting 'Pulse.Lib.C.Sizeof.c_sizeof <emitted-type>' where <emitted-type> is whatever the existing type printer already produces (Int32.t, ty_two_ints, array Int32.t, etc.).

The mini spec parser (hauntedc) recognises sizeof(<type>) and _Alignof(<type>) inside _ensures / _requires.