### PR TITLE
 Expose array_pts_to_len bridging lemma

### DIFF
--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -274,6 +274,16 @@ let length #t (a: array t) : GTot nat = A.length a
 let base_of #t (a: array t) : base_t = A.base_of a
 let offset_of #t (a: array t) : GTot nat = A.offset_of a
 
+ghost fn array_pts_to_len u#a (#a: Type u#a) (x: array a)
+                              (#p: perm) (#y: array_spec a)
+  preserves array_pts_to x p y
+  ensures pure (length x == array_spec_len y)
+{
+  unfold (array_pts_to x p y);
+  A.pts_to_mask_len x;
+  fold (array_pts_to x p y);
+}
+
 ghost fn arrayptr_pts_to_dup' u#a (#t: Type u#a) x y : duplicable_f (arrayptr_pts_to u#a #t x y) = {
   unfold arrayptr_pts_to x y;
   fold arrayptr_pts_to x y;

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -205,6 +205,16 @@ val length #t (a: array t) : GTot nat
 val base_of #t (a: array t) : base_t
 val offset_of #t (a: array t) : GTot nat
 
+/// Bridge between the handle's `length` and the spec's `array_spec_len`.
+/// `array_pts_to` is defined on top of `pts_to_mask`, whose length info
+/// is otherwise hidden by the abstraction; this exposes it so downstream
+/// proofs can discharge offset-bound VCs that compare a static
+/// `length x == K` refinement against `array_spec_len y`.
+ghost fn array_pts_to_len u#a (#a: Type u#a) (x: array a)
+                              (#p: perm) (#y: array_spec a)
+  preserves array_pts_to x p y
+  ensures pure (length x == array_spec_len y)
+
 /// Offset of x relative to y (may be negative).
 private let arrayptr_off (#t: Type) (x y: array t) : GTot int =
   offset_of x - offset_of y


### PR DESCRIPTION
array_pts_to abstracts pts_to_mask, hiding the underlying length info. Downstream proofs needing length x == array_spec_len y to discharge offset-bound VCs (e.g. typed memcpy/memmove wrapper preconditions on arrays with a static length refinement) have no way to obtain it. This one-line ghost fn forwards pts_to_mask_len through the abstraction.