### PR TITLE
Support struct-field writes through array/arrayptr deref

### DIFF
--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -2888,8 +2888,18 @@ impl<'a> Emitter<'a> {
                 }
                 StmtT::Assign(x, t) => {
                     // a[i].field = val → array_update / arrayptr_update
+                    // (*p).field = val → array_update / arrayptr_update at index 0
+                    //   (the `p->field` form, where `p` is an array/arrayptr)
                     if let ExprT::Member(base, fld) = &x.val {
-                        if let ExprT::Index(arr, idx) = &base.val {
+                        // Resolve the array/arrayptr being projected and the element index.
+                        // The deref form only applies to array/arrayptr pointers; plain
+                        // struct pointers fall through to the generic lvalue path below.
+                        let arr_and_idx: Option<(&Rc<Expr>, Option<&Rc<Expr>>)> = match &base.val {
+                            ExprT::Index(arr, idx) => Some((arr, Some(idx))),
+                            ExprT::Deref(ptr) => Some((ptr, None)),
+                            _ => None,
+                        };
+                        if let Some((arr, idx)) = arr_and_idx {
                             let arr_ty = env.infer_expr(arr).ok().map(|ty| env.vtype_whnf(ty));
                             let is_arrayptr = arr_ty
                                 .as_ref()
@@ -2897,14 +2907,24 @@ impl<'a> Emitter<'a> {
                                     matches!(ty.val, TypeT::Pointer(_, PointerKind::ArrayPtr))
                                 })
                                 .unwrap_or(false);
+                            let is_array = arr_ty
+                                .as_ref()
+                                .map(|ty| matches!(ty.val, TypeT::Pointer(_, PointerKind::Array)))
+                                .unwrap_or(false);
+                            let applies = idx.is_some() || is_array || is_arrayptr;
                             // Check that the element type is a struct
-                            if let Some(struct_name) = env.infer_expr(base).ok().and_then(|ty| {
-                                let ty = env.vtype_whnf(ty);
-                                match &ty.val {
-                                    TypeT::TypeRef(TypeRefKind::Struct(s)) => Some(s.val.clone()),
-                                    _ => None,
-                                }
-                            }) {
+                            if applies
+                                && let Some(struct_name) =
+                                    env.infer_expr(base).ok().and_then(|ty| {
+                                        let ty = env.vtype_whnf(ty);
+                                        match &ty.val {
+                                            TypeT::TypeRef(TypeRefKind::Struct(s)) => {
+                                                Some(s.val.clone())
+                                            }
+                                            _ => None,
+                                        }
+                                    })
+                            {
                                 let fn_name = if is_arrayptr {
                                     "arrayptr_update"
                                 } else {
@@ -2913,6 +2933,10 @@ impl<'a> Emitter<'a> {
                                 let arr_doc = match self.emit_expr(env, arr) {
                                     ExprKind::ArrayLValue(arr_doc) => arr_doc,
                                     arr_doc => arr_doc.to_rvalue(),
+                                };
+                                let idx_doc = match idx {
+                                    Some(idx) => self.emit_rvalue(env, idx),
+                                    None => Doc::text("0sz"),
                                 };
                                 let field_name = self.emit_name(Name::StructDirectFieldName(
                                     struct_name,
@@ -2924,7 +2948,7 @@ impl<'a> Emitter<'a> {
                                 return naryfn([
                                     Doc::text(fn_name),
                                     arr_doc,
-                                    self.emit_rvalue(env, idx),
+                                    idx_doc,
                                     upd_fn,
                                     self.emit_rvalue(env, t),
                                 ])

--- a/test/array_update/array_update.c
+++ b/test/array_update/array_update.c
@@ -54,3 +54,16 @@ void set_elem_fields(_array struct entry *a, uint32_t i, uint64_t v, uint64_t t)
     a[i].value = v;
     a[i].time = t;
 }
+
+// Like set_x, but instead of taking the whole array it takes an _arrayptr that
+// already points at the struct to update. The field is written through the
+// pointer (p->x), borrowing write permission from the parent array `arr`.
+void set_x_via_ptr(_arrayptr struct point *p, int val)
+  _preserves(_inline_pulse(arrayptr_pts_to $(p) $`arr))
+  _requires(_inline_pulse(array_pts_to_full $`arr 1.0R $`v))
+  _requires((bool) _inline_pulse(0 <= offset_of $(p) - offset_of $`arr
+    /\ offset_of $(p) - offset_of $`arr < array_spec_len $`v))
+  _ensures(_inline_pulse(exists* v_new. array_pts_to $`arr 1.0R v_new))
+{
+  p->x = val;
+}


### PR DESCRIPTION
`p->x = val` (i.e. `(*p).x = val`) where `p` is an `_array`/`_arrayptr` pointer previously failed to emit: the `StmtT::Assign` handler in the emit pass only recognized the indexed form `a[i].field = val` (`Member(Index(..))`), so the deref form `(*p).field` (`Member(Deref(..))`) fell through to the generic lvalue path and produced `cannot produce lvalue for (*p).x` plus an `admit()`.

Generalize the handler to resolve the projected base as either `Index(arr, idx)` or `Deref(ptr)`, emitting `array_update`/`arrayptr_update` at the given index or `0sz` for the deref case (since `(*p).f == p[0].f`). The deref branch is guarded by `is_array || is_arrayptr` so plain struct pointers still use the generic lvalue path.

Add a `set_x_via_ptr` regression test in array_update that writes a struct field through an `_arrayptr`, borrowing write permission from the parent array.