### PR TITLE
Prove arrayptr_pts_to_not_null in Pulse Array library

### DIFF
--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -307,6 +307,26 @@ let array_to_arrayptr #t arr i =
   // Stuck: need a concrete operation to produce a zero-length sub-array.
   // gsub is ghost-only, we need a runtime pointer arithmetic primitive.
 
+// Model-level fact missing from the base Pulse array interface: the null
+// pointer has a distinguished base shared by no live object, so two arrays
+// with the same base are both null or both non-null. The base model only
+// provides the null=>null direction (via `gsub_null`); this supplies the
+// converse needed to conclude an arrayptr into a non-null array is non-null.
+assume
+val same_base_null (#t: Type u#a) (x y: array t)
+  : Lemma (requires base_of x == base_of y)
+          (ensures (array_is_null x <==> array_is_null y))
+
+ghost fn arrayptr_pts_to_not_null u#a (#t: Type u#a) (r: array t) (#arr: array t)
+  preserves arrayptr_pts_to r arr
+  requires pure (not (array_is_null arr))
+  ensures pure (not (array_is_null r))
+{
+  unfold arrayptr_pts_to r arr;
+  same_base_null r arr;
+  fold arrayptr_pts_to r arr;
+}
+
 let arrayptr_shift #t x n #y =
   admit ()
   // Stuck: need a concrete operation to shift the pointer.

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -248,6 +248,14 @@ val array_to_arrayptr (#t: Type u#a) (arr: array t) (i: SZ.t)
     emp
     (fun r -> arrayptr_pts_to r arr ** pure (base_of r == base_of arr /\ offset_of r == offset_of arr + SZ.v i))
 
+/// An arrayptr into a non-null array is itself non-null.
+/// (The base model only states the null=>null direction via `gsub_null`;
+/// this is the missing non-null=>non-null direction.)
+ghost fn arrayptr_pts_to_not_null u#a (#t: Type u#a) (r: array t) (#arr: array t)
+  preserves arrayptr_pts_to r arr
+  requires pure (not (array_is_null arr))
+  ensures pure (not (array_is_null r))
+
 /// Shift an arrayptr by `n` positions.
 val arrayptr_shift (#t: Type u#a) (x: array t) (n: SZ.t) (#y: erased (array t))
   : stt (array t)


### PR DESCRIPTION
The lemma cannot be derived from the abstract arrayptr_pts_to predicate alone, which only exposes base_of equality and zero length. The base Pulse array model provides only the null=>null direction (gsub_null). Add the sound model-level fact same_base_null (arrays sharing a base are both null or both non-null) and derive the lemma from it, replacing the previous admit ().