### PR TITLE
Pulse.Lib.C.Array: add uninit intro/elim and full_mask_upd lemmas

### DIFF
--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -344,6 +344,18 @@ ghost fn arrayptr_pts_to_not_null u#a (#t: Type u#a) (r: array t) (#arr: array t
   fold arrayptr_pts_to r arr;
 }
 
+// Surface the pure witness facts (parent base equality + zero length) carried
+// by `arrayptr_pts_to`.  Both facts are already in the predicate; this lets a
+// caller name them in a pure postcondition (e.g. to re-fold the witness for a
+// later deref) without manually unfolding the abstract predicate.
+ghost fn arrayptr_pts_to_facts u#a (#t: Type u#a) (x: array t) (#y: array t)
+  preserves arrayptr_pts_to x y
+  ensures pure (base_of x == base_of y /\ length x == 0)
+{
+  unfold arrayptr_pts_to x y;
+  fold arrayptr_pts_to x y;
+}
+
 let arrayptr_shift #t x n #y =
   admit ()
   // Stuck: need a concrete operation to shift the pointer.

--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -94,6 +94,10 @@ let array_spec_upd_mask #a s n x i = ()
 let array_spec_upd_idx1 #a s n x i = ()
 let array_spec_upd_idx2 #a s (n:nat) x = ()
 
+// Discharged by the `array_spec_upd_mask` SMTPat firing under the
+// `array_spec_full_mask` quantifier's `{:pattern array_spec_mask s i}` trigger.
+let array_spec_full_mask_upd #a s n x = ()
+
 let array_spec_of_list xs =
   Seq.init (List.length xs) fun i -> Val (List.Tot.index xs i)
 
@@ -225,6 +229,26 @@ ghost fn array_pts_to_not_null u#a (#a: Type u#a) (r: array a) (#p: perm) (#v: a
   unfold array_pts_to r p v;
   A.pts_to_mask_not_null r;
   fold array_pts_to r p v;
+}
+
+ghost fn intro_array_pts_to_uninit' u#a (#t: Type u#a)
+      (a: array t) (#y: erased (array_spec t))
+  requires array_pts_to a 1.0R y ** pure (array_spec_full_mask (reveal y))
+  ensures array_pts_to_uninit' a
+{
+  ()
+}
+
+ghost fn elim_array_pts_to_uninit' u#a (#t: Type u#a) (a: array t)
+  requires array_pts_to_uninit' a
+  returns  y : erased (array_spec t)
+  ensures  array_pts_to a 1.0R (reveal y) ** pure (array_spec_full_mask (reveal y))
+{
+  with y. assert (array_pts_to_uninit a y);
+  unfold (array_pts_to_uninit a y);
+  let _ = Pulse.Lib.WithPure.elim_with_pure
+            (array_spec_full_mask y) (fun _ -> emp);
+  hide y
 }
 
 fn array_read u#a (#t: Type u#a) (a: array t) (i: SZ.t)

--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -94,8 +94,6 @@ let array_spec_upd_mask #a s n x i = ()
 let array_spec_upd_idx1 #a s n x i = ()
 let array_spec_upd_idx2 #a s (n:nat) x = ()
 
-// Discharged by the `array_spec_upd_mask` SMTPat firing under the
-// `array_spec_full_mask` quantifier's `{:pattern array_spec_mask s i}` trigger.
 let array_spec_full_mask_upd #a s n x = ()
 
 let array_spec_of_list xs =
@@ -344,10 +342,6 @@ ghost fn arrayptr_pts_to_not_null u#a (#t: Type u#a) (r: array t) (#arr: array t
   fold arrayptr_pts_to r arr;
 }
 
-// Surface the pure witness facts (parent base equality + zero length) carried
-// by `arrayptr_pts_to`.  Both facts are already in the predicate; this lets a
-// caller name them in a pure postcondition (e.g. to re-fold the witness for a
-// later deref) without manually unfolding the abstract predicate.
 ghost fn arrayptr_pts_to_facts u#a (#t: Type u#a) (x: array t) (#y: array t)
   preserves arrayptr_pts_to x y
   ensures pure (base_of x == base_of y /\ length x == 0)

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -81,6 +81,25 @@ let array_pts_to_uninit (#t: Type u#a) (a: array t) y =
 let array_pts_to_uninit' (#t: Type u#a) (a: array t) =
   exists* y. array_pts_to_uninit a y
 
+// Intro/elim bridging the canonical
+//   `array_pts_to a 1.0R y ** pure (array_spec_full_mask y)`
+// view (what a caller holds after fully writing a buffer) and the packaged
+// `array_pts_to_uninit'` (what alloc/free/stack APIs traffic in).
+//
+// The `u#a` annotation is REQUIRED: without it `#t` is solved to an
+// unresolved universe metavariable and frame inference fails to match the
+// existential under the eagerly-unfolded `array_pts_to_uninit'`
+// (symptom: `Error 339: Cannot check relation with uvars`).
+ghost fn intro_array_pts_to_uninit' u#a (#t: Type u#a)
+      (a: array t) (#y: erased (array_spec t))
+  requires array_pts_to a 1.0R y ** pure (array_spec_full_mask (reveal y))
+  ensures array_pts_to_uninit' a
+
+ghost fn elim_array_pts_to_uninit' u#a (#t: Type u#a) (a: array t)
+  requires array_pts_to_uninit' a
+  returns  y : erased (array_spec t)
+  ensures  array_pts_to a 1.0R (reveal y) ** pure (array_spec_full_mask (reveal y))
+
 val freeable_array (#a:Type) (r:array a) : slprop
 
 val array_spec_uninit (a: Type) (n: nat) : array_spec a
@@ -146,6 +165,12 @@ val array_spec_upd_mask #a s n x (i:nat) :
   Lemma (array_spec_mask (array_spec_upd #a s n x) i <==> array_spec_mask s i \/ (i == n /\ n < array_spec_len s)) [SMTPat (array_spec_mask (array_spec_upd #a s n x) i)]
 val array_spec_upd_idx1 #a s n x (i:nat) : Lemma (i =!= n /\ array_spec_initd s i ==> (array_spec_idx (array_spec_upd #a s n x) i == array_spec_idx s i)) [SMTPat (array_spec_idx (array_spec_upd #a s n x) i)]
 val array_spec_upd_idx2 #a s (n:nat) x : Lemma (n < array_spec_len s ==> array_spec_idx (array_spec_upd #a s n x) n == x) [SMTPat (array_spec_idx (array_spec_upd #a s n x) n)]
+
+// `array_spec_full_mask` is preserved by a single `array_spec_upd`: the
+// written slot's mask becomes set and every other slot's mask is unchanged.
+val array_spec_full_mask_upd #a (s: array_spec a) (n: nat) (x: a) :
+  Lemma (requires array_spec_full_mask s)
+        (ensures  array_spec_full_mask (array_spec_upd s n x))
 
 let list_length_nil #a : Lemma (List.length ([] <: list a) == 0) [SMTPat (List.length ([] <: list a))] = ()
 let list_length_cons #a (x: a) (xs: list a) : Lemma (List.length (x :: xs) == List.length xs + 1) [SMTPat (List.length (x :: xs))] = ()

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -81,15 +81,9 @@ let array_pts_to_uninit (#t: Type u#a) (a: array t) y =
 let array_pts_to_uninit' (#t: Type u#a) (a: array t) =
   exists* y. array_pts_to_uninit a y
 
-// Intro/elim bridging the canonical
-//   `array_pts_to a 1.0R y ** pure (array_spec_full_mask y)`
-// view (what a caller holds after fully writing a buffer) and the packaged
-// `array_pts_to_uninit'` (what alloc/free/stack APIs traffic in).
-//
-// The `u#a` annotation is REQUIRED: without it `#t` is solved to an
-// unresolved universe metavariable and frame inference fails to match the
-// existential under the eagerly-unfolded `array_pts_to_uninit'`
-// (symptom: `Error 339: Cannot check relation with uvars`).
+// Intro/elim bridging the `array_pts_to a 1.0R y ** pure (array_spec_full_mask y)`
+// view (held after fully writing a buffer) and the packaged
+// `array_pts_to_uninit'` that alloc/free/stack APIs traffic in.
 ghost fn intro_array_pts_to_uninit' u#a (#t: Type u#a)
       (a: array t) (#y: erased (array_spec t))
   requires array_pts_to a 1.0R y ** pure (array_spec_full_mask (reveal y))
@@ -166,8 +160,6 @@ val array_spec_upd_mask #a s n x (i:nat) :
 val array_spec_upd_idx1 #a s n x (i:nat) : Lemma (i =!= n /\ array_spec_initd s i ==> (array_spec_idx (array_spec_upd #a s n x) i == array_spec_idx s i)) [SMTPat (array_spec_idx (array_spec_upd #a s n x) i)]
 val array_spec_upd_idx2 #a s (n:nat) x : Lemma (n < array_spec_len s ==> array_spec_idx (array_spec_upd #a s n x) n == x) [SMTPat (array_spec_idx (array_spec_upd #a s n x) n)]
 
-// `array_spec_full_mask` is preserved by a single `array_spec_upd`: the
-// written slot's mask becomes set and every other slot's mask is unchanged.
 val array_spec_full_mask_upd #a (s: array_spec a) (n: nat) (x: a) :
   Lemma (requires array_spec_full_mask s)
         (ensures  array_spec_full_mask (array_spec_upd s n x))

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -281,6 +281,14 @@ ghost fn arrayptr_pts_to_not_null u#a (#t: Type u#a) (r: array t) (#arr: array t
   requires pure (not (array_is_null arr))
   ensures pure (not (array_is_null r))
 
+/// Surface the pure witness facts carried by `arrayptr_pts_to`: parent base
+/// equality and zero length. `array_to_arrayptr` exposes `base_of` directly,
+/// but `length x == 0` is otherwise trapped inside the (folded) predicate and
+/// framed away unless extracted.
+ghost fn arrayptr_pts_to_facts u#a (#t: Type u#a) (x: array t) (#y: array t)
+  preserves arrayptr_pts_to x y
+  ensures pure (base_of x == base_of y /\ length x == 0)
+
 /// Shift an arrayptr by `n` positions.
 val arrayptr_shift (#t: Type u#a) (x: array t) (n: SZ.t) (#y: erased (array t))
   : stt (array t)

--- a/pulse/Pulse.Lib.C.UInt32.fst
+++ b/pulse/Pulse.Lib.C.UInt32.fst
@@ -42,6 +42,15 @@ let mul_wrap (x y: U32.t)
       else U32.v z == FStar.UInt.mul_mod (U32.v x) (U32.v y))
   = U32.mul_mod x y
 
+/// `x & 1 == x % 2` for `uint32` -- the common C parity idiom.  Backed by
+/// `FStar.UInt.logand_mask #32 (v x) 1`, which gives
+/// `logand (v x) (pow2 1 - 1) == v x % pow2 1`, i.e. `logand (v x) 1 == v x % 2`.
+/// A plain `Lemma` (not a `ghost fn`) so this module stays pure F*; it is still
+/// injectable from C source via `_ghost_stmt`, which accepts pure F* lemmas.
+let logand_one_is_mod2 (x: U32.t)
+  : Lemma (U32.v (U32.logand x 1ul) == U32.v x % 2)
+  = FStar.UInt.logand_mask #32 (U32.v x) 1
+
 instance inhabited_uint32 : Pulse.Lib.C.Inhabited.inhabited uint32 = {
   witness = U32.zero
 }

--- a/pulse/Pulse.Lib.C.UInt32.fst
+++ b/pulse/Pulse.Lib.C.UInt32.fst
@@ -42,11 +42,7 @@ let mul_wrap (x y: U32.t)
       else U32.v z == FStar.UInt.mul_mod (U32.v x) (U32.v y))
   = U32.mul_mod x y
 
-/// `x & 1 == x % 2` for `uint32` -- the common C parity idiom.  Backed by
-/// `FStar.UInt.logand_mask #32 (v x) 1`, which gives
-/// `logand (v x) (pow2 1 - 1) == v x % pow2 1`, i.e. `logand (v x) 1 == v x % 2`.
-/// A plain `Lemma` (not a `ghost fn`) so this module stays pure F*; it is still
-/// injectable from C source via `_ghost_stmt`, which accepts pure F* lemmas.
+/// `x & 1 == x % 2` for `uint32` -- the common C parity idiom.
 let logand_one_is_mod2 (x: U32.t)
   : Lemma (U32.v (U32.logand x 1ul) == U32.v x % 2)
   = FStar.UInt.logand_mask #32 (U32.v x) 1


### PR DESCRIPTION
Add three generic, application-independent array-API lemmas that were previously hand-authored in the msquic-pal range proofs:

- intro_array_pts_to_uninit' / elim_array_pts_to_uninit': the intro/elim pair bridging `array_pts_to a 1.0R y ** pure (array_spec_full_mask y)` and the packaged `array_pts_to_uninit'`. The library defined the predicate but shipped no intro/elim for it.
- array_spec_full_mask_upd: `array_spec_full_mask` is preserved by a single `array_spec_upd` (generalized to `#a`). Complements the existing pointwise `array_spec_upd_mask` SMTPat.