### PR TITLE
Bump F* to nightly-2026-06-24

### DIFF
--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-06-19 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-06-24 "$@"


### PR DESCRIPTION
Update the pinned F*/Pulse nightly from 2026-06-19 to 2026-06-24 (the latest available). The full test suite verifies against the new nightly with no source changes required.