### PR TITLE
Update to F* nightly 2026-06-26 and use FStar.Float{32,64}

### DIFF
--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-06-19 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-06-26 "$@"

--- a/pulse/Pulse.Lib.C.fsti
+++ b/pulse/Pulse.Lib.C.fsti
@@ -16,38 +16,45 @@ include Pulse.Lib.WithPure
 open Pulse.Lib.Core
 let _Bool = bool
 
-type float32
-type float64
+// C `float`/`double` are backed by the upstream IEEE-754 float modules.
+let float32 = FStar.Float32.t
+let float64 = FStar.Float64.t
 
-val float32_zero : float32
-val float64_zero : float64
+let float32_zero : float32 = FStar.Float32.zero
+let float64_zero : float64 = FStar.Float64.zero
 
-val float32_of_string : string -> float32
-val float64_of_string : string -> float64
+// C float literals are concrete strings, replaced with the corresponding C
+// constant during extraction.
+let float32_of_string (s: string) : float32 = FStar.Float32.of_literal s
+let float64_of_string (s: string) : float64 = FStar.Float64.of_literal s
 
-val float32_neg : float32 -> float32
-val float32_add : float32 -> float32 -> float32
-val float32_sub : float32 -> float32 -> float32
-val float32_mul : float32 -> float32 -> float32
-val float32_div : float32 -> float32 -> float32
-val float32_eq : float32 -> float32 -> bool
-val float32_lt : float32 -> float32 -> bool
-val float32_lte : float32 -> float32 -> bool
-val float32_to_bool : float32 -> bool
-val float32_of_bool : bool -> float32
+// Unary negation: `-x` is `0 - x`.
+let float32_neg (x: float32) : float32 = FStar.Float32.sub FStar.Float32.zero x
+let float32_add : float32 -> float32 -> float32 = FStar.Float32.add
+let float32_sub : float32 -> float32 -> float32 = FStar.Float32.sub
+let float32_mul : float32 -> float32 -> float32 = FStar.Float32.mul
+let float32_div : float32 -> float32 -> float32 = FStar.Float32.div
+// C `==` on floats is IEEE-754 equality (NaN <> NaN, +0.0 == -0.0).
+let float32_eq : float32 -> float32 -> bool = FStar.Float32.ieee_eq
+let float32_lt : float32 -> float32 -> bool = FStar.Float32.lt
+let float32_lte : float32 -> float32 -> bool = FStar.Float32.lte
+// C truth value of a float: nonzero is true (so NaN is true, +/-0.0 is false).
+let float32_to_bool (x: float32) : bool = not (FStar.Float32.ieee_eq x FStar.Float32.zero)
+let float32_of_bool (b: bool) : float32 = if b then FStar.Float32.one else FStar.Float32.zero
+// Truncation to / from integers has no upstream realization yet.
 val float32_to_int : float32 -> int
 val float32_of_int : int -> float32
 
-val float64_neg : float64 -> float64
-val float64_add : float64 -> float64 -> float64
-val float64_sub : float64 -> float64 -> float64
-val float64_mul : float64 -> float64 -> float64
-val float64_div : float64 -> float64 -> float64
-val float64_eq : float64 -> float64 -> bool
-val float64_lt : float64 -> float64 -> bool
-val float64_lte : float64 -> float64 -> bool
-val float64_to_bool : float64 -> bool
-val float64_of_bool : bool -> float64
+let float64_neg (x: float64) : float64 = FStar.Float64.sub FStar.Float64.zero x
+let float64_add : float64 -> float64 -> float64 = FStar.Float64.add
+let float64_sub : float64 -> float64 -> float64 = FStar.Float64.sub
+let float64_mul : float64 -> float64 -> float64 = FStar.Float64.mul
+let float64_div : float64 -> float64 -> float64 = FStar.Float64.div
+let float64_eq : float64 -> float64 -> bool = FStar.Float64.ieee_eq
+let float64_lt : float64 -> float64 -> bool = FStar.Float64.lt
+let float64_lte : float64 -> float64 -> bool = FStar.Float64.lte
+let float64_to_bool (x: float64) : bool = not (FStar.Float64.ieee_eq x FStar.Float64.zero)
+let float64_of_bool (b: bool) : float64 = if b then FStar.Float64.one else FStar.Float64.zero
 val float64_to_int : float64 -> int
 val float64_of_int : int -> float64
 

--- a/src/pass/elab.rs
+++ b/src/pass/elab.rs
@@ -911,6 +911,18 @@ impl<'a> Elaborator<'a> {
         self.elab_slprops(env, ensures);
         if let Some(dec) = decreases {
             self.elab_rvalue(env, Rc::make_mut(dec), None);
+            // Machine-integer decreases measures (e.g. `hi - lo` of type
+            // size_t) are not well-founded under F*'s `<<` relation, so
+            // termination checking fails. Coerce them to mathematical
+            // integers (`SpecInt`), which emits e.g. `SizeT.v (...)`.
+            if let Ok(dec_ty) = env.infer_expr(dec) {
+                if matches!(
+                    &env.vtype_whnf(dec_ty).val,
+                    TypeT::Int { .. } | TypeT::SizeT | TypeT::PtrdiffT
+                ) {
+                    cast_to(dec, TypeT::SpecInt.with_loc(dec.loc.clone()));
+                }
+            }
         }
     }
 

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -3542,7 +3542,8 @@ impl<'a> Emitter<'a> {
             .push_this(TypeT::TypeRef(k.clone()).with_loc(name.loc.clone()))
             .with_loc(name.loc.clone());
         let this_arg = parens(
-            self.emit_name(Name::Var(this.val.clone()))
+            Doc::text("[@@@mkey] ")
+                .append(self.emit_name(Name::Var(this.val.clone())))
                 .append(":")
                 .append(Doc::line())
                 .append(t),

--- a/test/pointer_view/pointer_view.c
+++ b/test/pointer_view/pointer_view.c
@@ -101,7 +101,9 @@ bool ptr_is_null(_plain node *n) {
 /* Recursive traversal: `node *` parameter resolves to the `list` view; the
  * `node *nx` local does too. */
 _rec void traverse(const node *head)
-    _decreases(_elements_of(head))
+    // Pulse can't currently prove termination from the opaque _elements_of
+    // accessor, so we measure on the predicate's spec value directly.
+    _decreases((spec_list) _inline_pulse(reveal $`val_head_0))
 {
     if (head == NULL) {
         _ghost_stmt(Pointer_view_include2.is_list_nil_case $(head));

--- a/test/recursive_struct/recursive_struct.c
+++ b/test/recursive_struct/recursive_struct.c
@@ -105,7 +105,9 @@ _include_pulse(Recursive_struct_include2,
  *    to _plain parameter. Regression: without elaborating fn_decl types before
  *    pre-registration, this gets a spurious (node[?]) cast → assert False. */
 _rec void traverse(const list head)
-    _decreases(_elements_of(head))
+    // Pulse can't currently prove termination from the opaque _elements_of
+    // accessor, so we measure on the predicate's spec value directly.
+    _decreases((spec_list) _inline_pulse(reveal $`val_head_0))
 {
     if (head == NULL) {
         _ghost_stmt(Recursive_struct_include2.is_list_nil_case $(head));


### PR DESCRIPTION
Fixes test failures introduced by the F* nightly bump and switches floating-point support onto the upstream FStar.Float32/FStar.Float64 modules.

- elab: coerce machine-int `decreases` measures to SpecInt so termination is checked over mathematical ints (raw size_t/int are no longer well-founded under the new nightly's `<<` relation), fixing Error 19 in rec_fn / recursive_functions.
- emit: add `[@@@mkey]` to typedef refine-value predicates, fixing Error 339 ("Cannot check relation with uvars") in pointer_view / recursive_struct.
- pointer_view / recursive_struct: Pulse currently can't prove termination from the opaque `_elements_of` accessor in `decreases`, so the tests now spell the measure out with `_inline_pulse` over the predicate's revealed spec value instead. (due to https://github.com/FStarLang/FStar/issues/4337)
- Pulse.Lib.C: back `float32`/`float64` with FStar.Float32.t / FStar.Float64.t and define the ops over them (IEEE eq for C `==`, `0 - x` for negation), keeping all `Pulse.Lib.C.float*` names so emit is unchanged. to_int/of_int remain abstract.