### PR TITLE
Fix switch case body grouping

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -1638,30 +1638,57 @@ public:
         return {};
       }
 
-      // Walk the compound statement collecting case/default groups
+      // Clang attaches only the first statement after a label to CaseStmt or
+      // DefaultStmt. The remaining statements are siblings in the compound
+      // body, but are still controlled by that label in C.
+      struct SwitchGroup {
+        Stmt *label;
+        bool isDefault;
+        std::vector<Expr *> caseValues;
+        std::vector<Stmt *> body;
+      };
+      std::vector<SwitchGroup> groups;
       bool seenDefault = false;
+      SwitchGroup *currentGroup = nullptr;
       for (auto *child : comp->body()) {
-        auto childLoc = getRange(child->getSourceRange());
-
         if (auto *cs = dyn_cast<CaseStmt>(child)) {
+          auto childLoc = getRange(child->getSourceRange());
           if (seenDefault) {
             reportUnsupported(cs->getSourceRange(), childLoc,
                               "default must be the last case in switch", "");
             break;
           }
 
-          // Collect all case values from chained cases (case 1: case 2: ...)
-          // and find the final sub-statement
-          std::vector<Expr *> caseValues;
+          groups.push_back({child, false, {}, {}});
+          currentGroup = &groups.back();
           Stmt *caseBody = child;
           while (auto *innerCs = dyn_cast<CaseStmt>(caseBody)) {
-            caseValues.push_back(innerCs->getLHS());
+            currentGroup->caseValues.push_back(innerCs->getLHS());
             caseBody = innerCs->getSubStmt();
           }
+          if (caseBody)
+            currentGroup->body.push_back(caseBody);
+        } else if (auto *ds = dyn_cast<DefaultStmt>(child)) {
+          seenDefault = true;
+          groups.push_back({child, true, {}, {}});
+          currentGroup = &groups.back();
+          if (ds->getSubStmt())
+            currentGroup->body.push_back(ds->getSubStmt());
+        } else if (currentGroup) {
+          currentGroup->body.push_back(child);
+        } else {
+          // Statements before the first label are unreachable in C, but retain
+          // the old behavior so malformed inputs still receive diagnostics.
+          trStmt(stmts, child);
+        }
+      }
 
+      for (auto &group : groups) {
+        auto childLoc = getRange(group.label->getSourceRange());
+        if (!group.isDefault) {
           // Build match condition: scrut == v1 || scrut == v2 || ...
           Rc<ir::Expr> matchCond = mk_bool_lit(childLoc.clone(), false);
-          for (auto *cv : caseValues) {
+          for (auto *cv : group.caseValues) {
             auto scrutRead = mk_rvalue_lvalue(
                 childLoc.clone(),
                 mk_lvalue_var(childLoc.clone(), scrutId.clone()));
@@ -1690,18 +1717,15 @@ public:
           thenStmts.push(mk_assign(
               childLoc.clone(), mk_lvalue_var(childLoc.clone(), hitId.clone()),
               mk_bool_lit(childLoc.clone(), true)));
-          if (caseBody)
-            trStmt(thenStmts, caseBody);
+          for (auto *bodyStmt : group.body)
+            trStmt(thenStmts, bodyStmt);
 
           auto elseStmts = Vec<Rc<ir::Stmt>>::new_();
           stmts.push(mk_if(std::move(childLoc), std::move(cond),
                            std::move(thenStmts), std::move(elseStmts),
                            Vec<Rc<ir::Expr>>::new_()));
 
-        } else if (dyn_cast<DefaultStmt>(child)) {
-          seenDefault = true;
-          auto *ds = dyn_cast<DefaultStmt>(child);
-
+        } else {
           // Condition: !brk
           auto notBrk = mk_rvalue_unop(
               childLoc.clone(), ir::UnOp::Not(),
@@ -1712,17 +1736,13 @@ public:
           thenStmts.push(mk_assign(
               childLoc.clone(), mk_lvalue_var(childLoc.clone(), hitId.clone()),
               mk_bool_lit(childLoc.clone(), true)));
-          if (ds->getSubStmt())
-            trStmt(thenStmts, ds->getSubStmt());
+          for (auto *bodyStmt : group.body)
+            trStmt(thenStmts, bodyStmt);
 
           auto elseStmts = Vec<Rc<ir::Stmt>>::new_();
           stmts.push(mk_if(std::move(childLoc), std::move(notBrk),
                            std::move(thenStmts), std::move(elseStmts),
                            Vec<Rc<ir::Expr>>::new_()));
-
-        } else {
-          // Bare statement outside case/default — translate directly
-          trStmt(stmts, child);
         }
       }
 

--- a/test/switch_stmt/switch_stmt.c
+++ b/test/switch_stmt/switch_stmt.c
@@ -26,6 +26,9 @@ int32_t day_type(int32_t day)
 /* Switch with fall-through */
 int32_t classify(int32_t x)
     _requires(x >= 0 && x <= 3)
+    _ensures(x == 0 ==> return == 10)
+    _ensures((x == 1 || x == 2) ==> return == 20)
+    _ensures(x == 3 ==> return == 30)
 {
     int32_t r = 0;
     switch (x) {


### PR DESCRIPTION
Clang stores only the first statement after a case or default label beneath the label AST node. Remaining statements are siblings in the enclosing CompoundStmt, even though C semantics keep them under that label. PAL previously translated those siblings at switch scope, which could make assignments and break statements execute unconditionally.

Collect each label and all following sibling statements up to the next label into an explicit switch group before lowering. Preserve chained case values and fallthrough through PAL's existing hit flag, and translate the complete group body inside the generated conditional branch.

Strengthen the switch regression with postconditions for every classify arm so misplaced case statements can no longer pass unnoticed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 6546d132-a5e6-4e6c-a59a-bd7ab6d4eb5a