### PR TITLE
Stack array read fix

### DIFF
--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -1716,9 +1716,16 @@ impl<'a> Emitter<'a> {
                     .as_ref()
                     .is_some_and(|ty| matches!(&ty.val, TypeT::Pointer(_, PointerKind::ArrayPtr)));
 
-                let (arr_doc, use_spec_idx) = match self.emit_expr(env, arr) {
-                    ExprKind::ArrayLValue(arr_doc) => (arr_doc, false),
-                    arr_doc => (arr_doc.to_rvalue(), is_fixed_array),
+                // A fixed-array value is a *pure* `array_spec` only when it is an
+                // RValue (e.g. a global pure array or a by-value struct field), in
+                // which case it must be indexed with `array_spec_idx`. A stack-local
+                // array is an LValue holding a runtime `array` handle, so it must be
+                // read with `array_read`/`arrayptr_read` like any other live array.
+                let arr_kind = self.emit_expr(env, arr);
+                let use_spec_idx = is_fixed_array && matches!(arr_kind, ExprKind::RValue(_));
+                let arr_doc = match arr_kind {
+                    ExprKind::ArrayLValue(arr_doc) => arr_doc,
+                    other => other.to_rvalue(),
                 };
                 let idx_doc = self.emit_rvalue(env, idx);
 

--- a/test/stack_arrays/stack_arrays.c
+++ b/test/stack_arrays/stack_arrays.c
@@ -12,22 +12,14 @@ void test_vla(int len)
     arr[0] = 42;
 }
 
-/*
- * Tracks a known PAL emitter bug: reading an element of a constant-sized
- * stack-local array.
- *
- * A constant-sized local array `T a[N]` is registered as an LValue local. When
- * reading `a[i]`, the emitter (`emit.rs` `ExprT::Index`) treats any
- * fixed-array-typed value as a pure spec value and emits
- * `array_spec_idx (!var_a) i` — a pure `Seq` read applied to a runtime `array`
- * handle — which is ill-typed. The write path (`array_write (!var_a) i v`)
- * already works, so this bug is only exercised by a *read*.
- *
- * This test is EXPECTED TO FAIL F* verification until the emitter is fixed to
- * route the stack-array (LValue) read through `array_read` instead of
- * `array_spec_idx`. It exists to track the issue.
- */
+/* Reading an element of a constant-sized stack-local array. */
 int stack_array_read()
+    _ensures(return == 42)
+{
+    int arr[2];
+    arr[0] = 42;
+    return arr[0];
+}
     _ensures(return == 42)
 {
     int arr[2];

--- a/test/stack_arrays/stack_arrays.c
+++ b/test/stack_arrays/stack_arrays.c
@@ -11,3 +11,26 @@ void test_vla(int len)
     int arr[len];
     arr[0] = 42;
 }
+
+/*
+ * Tracks a known PAL emitter bug: reading an element of a constant-sized
+ * stack-local array.
+ *
+ * A constant-sized local array `T a[N]` is registered as an LValue local. When
+ * reading `a[i]`, the emitter (`emit.rs` `ExprT::Index`) treats any
+ * fixed-array-typed value as a pure spec value and emits
+ * `array_spec_idx (!var_a) i` — a pure `Seq` read applied to a runtime `array`
+ * handle — which is ill-typed. The write path (`array_write (!var_a) i v`)
+ * already works, so this bug is only exercised by a *read*.
+ *
+ * This test is EXPECTED TO FAIL F* verification until the emitter is fixed to
+ * route the stack-array (LValue) read through `array_read` instead of
+ * `array_spec_idx`. It exists to track the issue.
+ */
+int stack_array_read()
+    _ensures(return == 42)
+{
+    int arr[2];
+    arr[0] = 42;
+    return arr[0];
+}

--- a/test/stack_arrays/stack_arrays.c
+++ b/test/stack_arrays/stack_arrays.c
@@ -20,9 +20,3 @@ int stack_array_read()
     arr[0] = 42;
     return arr[0];
 }
-    _ensures(return == 42)
-{
-    int arr[2];
-    arr[0] = 42;
-    return arr[0];
-}


### PR DESCRIPTION
Originally, we emit `array_spec_idx` for reading stack arrays, which is originally only for pure mathematical values like `Seq`.
This fix now emits `array_read` instead