### PR TITLE
Support sizeof of fixed-size arrays

### DIFF
--- a/pulse/Pulse.Lib.C.Sizeof.fsti
+++ b/pulse/Pulse.Lib.C.Sizeof.fsti
@@ -1,6 +1,7 @@
 module Pulse.Lib.C.Sizeof
 
 open FStar.SizeT
+module Arr = Pulse.Lib.C.Array
 
 /// Opaque byte-size of an arbitrary F* type, intended to be used as the
 /// translation of `sizeof(T)` from C. The function commits to no
@@ -11,23 +12,20 @@ val c_sizeof (a: Type u#a) : t
 /// as the translation of `_Alignof(T)` from C.
 val c_alignof (a: Type u#a) : t
 
-/// Phantom representation of the C array type `a[n]`, used only as the type
-/// argument to `c_sizeof` when translating `sizeof(a[n])`. It carries the
-/// length `n` so the size of an array can be related to its element size.
-val c_array (a: Type u#a) (n: nat) : Type u#a
-
 /// Sizes are non-negative. Strict positivity does not hold for every type: a
 /// zero-length array `a[0]` has size 0 (see `c_sizeof_array`).
 val c_sizeof_nonneg (a: Type u#a)
   : Lemma (v (c_sizeof a) >= 0)
     [SMTPat (v (c_sizeof a))]
 
-/// The size of the array type `a[n]` is the element size times the length.
-/// This is an idealized model axiom: like `Pulse.Lib.C.Array.alloc`, it makes
-/// no attempt to rule out `size_t` overflow for large `n`.
+/// The size of the C array type `a[n]` (modelled by `full_array_lspec a n`, the
+/// same length-indexed array type used everywhere else) is the element size
+/// times the length. This is an idealized model axiom: like
+/// `Pulse.Lib.C.Array.alloc`, it makes no attempt to rule out `size_t` overflow
+/// for large `n`.
 val c_sizeof_array (a: Type u#a) (n: nat)
-  : Lemma (v (c_sizeof (c_array a n)) == v (c_sizeof a) * n)
-    [SMTPat (v (c_sizeof (c_array a n)))]
+  : Lemma (v (c_sizeof (Arr.full_array_lspec a n)) == v (c_sizeof a) * n)
+    [SMTPat (v (c_sizeof (Arr.full_array_lspec a n)))]
 
 /// Alignments are strictly positive on any conforming C implementation.
 val c_alignof_pos (a: Type u#a)

--- a/pulse/Pulse.Lib.C.Sizeof.fsti
+++ b/pulse/Pulse.Lib.C.Sizeof.fsti
@@ -4,17 +4,30 @@ open FStar.SizeT
 
 /// Opaque byte-size of an arbitrary F* type, intended to be used as the
 /// translation of `sizeof(T)` from C. The function commits to no
-/// particular value — only that whatever it returns is strictly positive.
+/// particular value — only that whatever it returns is non-negative.
 val c_sizeof (a: Type u#a) : t
 
 /// Opaque alignment-in-bytes of an arbitrary F* type, intended to be used
 /// as the translation of `_Alignof(T)` from C.
 val c_alignof (a: Type u#a) : t
 
-/// Sizes are strictly positive on any conforming C implementation.
-val c_sizeof_pos (a: Type u#a)
-  : Lemma (v (c_sizeof a) > 0)
+/// Phantom representation of the C array type `a[n]`, used only as the type
+/// argument to `c_sizeof` when translating `sizeof(a[n])`. It carries the
+/// length `n` so the size of an array can be related to its element size.
+val c_array (a: Type u#a) (n: nat) : Type u#a
+
+/// Sizes are non-negative. Strict positivity does not hold for every type: a
+/// zero-length array `a[0]` has size 0 (see `c_sizeof_array`).
+val c_sizeof_nonneg (a: Type u#a)
+  : Lemma (v (c_sizeof a) >= 0)
     [SMTPat (v (c_sizeof a))]
+
+/// The size of the array type `a[n]` is the element size times the length.
+/// This is an idealized model axiom: like `Pulse.Lib.C.Array.alloc`, it makes
+/// no attempt to rule out `size_t` overflow for large `n`.
+val c_sizeof_array (a: Type u#a) (n: nat)
+  : Lemma (v (c_sizeof (c_array a n)) == v (c_sizeof a) * n)
+    [SMTPat (v (c_sizeof (c_array a n)))]
 
 /// Alignments are strictly positive on any conforming C implementation.
 val c_alignof_pos (a: Type u#a)

--- a/src/hauntedc.rs
+++ b/src/hauntedc.rs
@@ -733,24 +733,31 @@ fn expr_parser<
                 type_name
                     .clone()
                     .then(
-                        select! { Token::Integer(_, _) => () }
+                        select! { Token::Integer(i, _) => i }
                             .delimited_by(punct(Punct::LBracket), punct(Punct::RBracket))
                             .or_not(),
                     )
                     .delimited_by(punct(Punct::LParen), punct(Punct::RParen)),
             )
-            .map_with(|(is_sizeof, (ty, arr_opt)), extra| -> Expr {
-                let loc = sift.resolve_source_info(&extra.span());
+            .try_map(|(is_sizeof, (ty, arr_opt)), span| {
+                let loc = sift.resolve_source_info(&span);
                 let inner_ty = match arr_opt {
                     None => ty,
-                    Some(()) => TypeT::Pointer(ty, PointerKind::Array).with_loc(loc.clone()),
+                    // `sizeof(T[N])` denotes the array type itself (no decay
+                    // under `sizeof`), so keep the length as a `FixedArray`.
+                    Some(i) => {
+                        let n = str::parse::<u64>(i).map_err(|_| {
+                            Rich::custom(span, format!("invalid array length: {i}"))
+                        })?;
+                        TypeT::FixedArray(ty, n).with_loc(loc.clone())
+                    }
                 };
                 let expr_t = if is_sizeof {
                     ExprT::SizeOf(inner_ty)
                 } else {
                     ExprT::AlignOf(inner_ty)
                 };
-                expr_t.with_loc(loc).into()
+                Ok(expr_t.with_loc(loc).into())
             })
             .boxed(),
             ident

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -363,8 +363,8 @@ pub enum ExprT {
     AssignExpr(Rc<Expr>, Rc<Expr>),
     /// `sizeof(T)` — translated to an opaque `c_sizeof T` call where `T`
     /// is the F* type PAL uses to represent the C type being measured. A
-    /// fixed-size array `T[N]` is measured as `c_sizeof (c_array T N)`, whose
-    /// size is related to the element size by the `c_sizeof_array` axiom.
+    /// fixed-size array `T[N]` is measured as `c_sizeof (full_array_lspec T N)`,
+    /// whose size is related to the element size by the `c_sizeof_array` axiom.
     SizeOf(Rc<Type>),
     /// `_Alignof(T)` / `__alignof__(T)` — translated to `c_alignof T`.
     AlignOf(Rc<Type>),

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -362,7 +362,9 @@ pub enum ExprT {
     /// Lowered to Assign statement + value in elab pass.
     AssignExpr(Rc<Expr>, Rc<Expr>),
     /// `sizeof(T)` — translated to an opaque `c_sizeof T` call where `T`
-    /// is the F* type PAL uses to represent the C type being measured.
+    /// is the F* type PAL uses to represent the C type being measured. A
+    /// fixed-size array `T[N]` is measured as `c_sizeof (c_array T N)`, whose
+    /// size is related to the element size by the `c_sizeof_array` axiom.
     SizeOf(Rc<Type>),
     /// `_Alignof(T)` / `__alignof__(T)` — translated to `c_alignof T`.
     AlignOf(Rc<Type>),

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -3144,18 +3144,15 @@ impl<'a> Emitter<'a> {
                     }
                 }
                 ExprT::SizeOf(ty) => {
-                    // For a fixed-size array `T[N]`, emit `c_sizeof (c_array T N)`
-                    // so the length participates in the size (see the
-                    // `c_sizeof_array` axiom). Other types size opaquely.
-                    let ty_doc = match &ty.val {
-                        TypeT::FixedArray(elem, len) => naryfn([
-                            Doc::text("Pulse.Lib.C.Sizeof.c_array"),
-                            self.emit_type(env, elem),
-                            Doc::text(len.to_string()),
-                        ]),
-                        _ => self.emit_type(env, ty),
-                    };
-                    unaryfn(Doc::text("Pulse.Lib.C.Sizeof.c_sizeof"), ty_doc)
+                    // `emit_type` renders a fixed-size array `T[N]` as
+                    // `full_array_lspec T N`, so `sizeof(T[N])` becomes
+                    // `c_sizeof (full_array_lspec T N)` and its length
+                    // participates in the size (see the `c_sizeof_array` axiom).
+                    // Other types size opaquely.
+                    unaryfn(
+                        Doc::text("Pulse.Lib.C.Sizeof.c_sizeof"),
+                        self.emit_type(env, ty),
+                    )
                 }
                 ExprT::AlignOf(ty) => {
                     let ty_doc = match &ty.val {

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -3144,11 +3144,15 @@ impl<'a> Emitter<'a> {
                     }
                 }
                 ExprT::SizeOf(ty) => {
-                    // For FixedArray, emit as `array T` to match annotation parser output
+                    // For a fixed-size array `T[N]`, emit `c_sizeof (c_array T N)`
+                    // so the length participates in the size (see the
+                    // `c_sizeof_array` axiom). Other types size opaquely.
                     let ty_doc = match &ty.val {
-                        TypeT::FixedArray(elem, _) => {
-                            unaryfn(Doc::text("array"), self.emit_type(env, elem))
-                        }
+                        TypeT::FixedArray(elem, len) => naryfn([
+                            Doc::text("Pulse.Lib.C.Sizeof.c_array"),
+                            self.emit_type(env, elem),
+                            Doc::text(len.to_string()),
+                        ]),
                         _ => self.emit_type(env, ty),
                     };
                     unaryfn(Doc::text("Pulse.Lib.C.Sizeof.c_sizeof"), ty_doc)

--- a/test/sizeof/sizeof.c
+++ b/test/sizeof/sizeof.c
@@ -36,3 +36,20 @@ size_t align_of_int(void)
 {
     return _Alignof(int);
 }
+
+// Array sizeof related to element size. PAL translates `sizeof(int[8])` to
+// `c_sizeof (c_array int 8)`, and the `c_sizeof_array` axiom relates it to
+// `sizeof(int) * 8`.
+size_t size_of_int_array_len(void)
+    _ensures(return == sizeof(int) * 8)
+{
+    return sizeof(int[8]);
+}
+
+// Zero-length array has size 0: `c_sizeof (c_array int 0)` reduces to
+// `sizeof(int) * 0 == 0` via the `c_sizeof_array` axiom.
+size_t size_of_int_array_zero(void)
+    _ensures(return == 0)
+{
+    return sizeof(int[0]);
+}

--- a/test/sizeof/sizeof.c
+++ b/test/sizeof/sizeof.c
@@ -38,15 +38,15 @@ size_t align_of_int(void)
 }
 
 // Array sizeof related to element size. PAL translates `sizeof(int[8])` to
-// `c_sizeof (c_array int 8)`, and the `c_sizeof_array` axiom relates it to
-// `sizeof(int) * 8`.
+// `c_sizeof (full_array_lspec int 8)`, and the `c_sizeof_array` axiom relates
+// it to `sizeof(int) * 8`.
 size_t size_of_int_array_len(void)
     _ensures(return == sizeof(int) * 8)
 {
     return sizeof(int[8]);
 }
 
-// Zero-length array has size 0: `c_sizeof (c_array int 0)` reduces to
+// Zero-length array has size 0: `c_sizeof (full_array_lspec int 0)` reduces to
 // `sizeof(int) * 0 == 0` via the `c_sizeof_array` axiom.
 size_t size_of_int_array_zero(void)
     _ensures(return == 0)


### PR DESCRIPTION
We often use `sizeof(array) / sizeof(array[0])` to compute the number of elements of an array.
To do so, we need to support computing `sizeof` an array

Modified:
- `sizeof` returns non-negative number (not just positive)
- Axiom on what `sizeof(array)` returns
- PAL now keep tracks of length of arrays
- Added tests, including array of length `0` 