### PR TITLE
Bump F* nightly to 2026-07-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ it passes, the implementation satisfies the spec. More availabe at [`examples/`]
 | LLVM dev headers | 20.x | `llvm-config`, `libclang-cpp20-dev`, `libclang-20-dev` |
 | g++ | recent | builds the C++ FFI ([`cpp/impl.cpp`](cpp/impl.cpp)) |
 | Rust | 2024 edition | compiles the PAL binary |
-| F\*/Pulse | nightly 2026-07-23 | verifies generated `.fst` output |
+| F\*/Pulse | nightly 2026-07-29 | verifies generated `.fst` output |
 
 ### Setup (Ubuntu / Debian)
 

--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-07-23 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-07-29 "$@"


### PR DESCRIPTION
Routine nightly bump; full test suite passes with divergent-default emission and the _total annotation.