### PR TITLE
Emit direct matches for terminal-break switches

### DIFF
--- a/cpp/iface.zng
+++ b/cpp/iface.zng
@@ -25,6 +25,7 @@ use crate::ir::SourceInfo as SourceInfo;
 use crate::ir::Type as Type;
 use crate::ir::Stmt as Stmt;
 use crate::ir::Expr as Expr;
+use crate::ir::MatchBranch as MatchBranch;
 use crate::ir::UnOp as UnOp;
 use crate::ir::BinOp as BinOp;
 use crate::ir::ParamMode as ParamMode;
@@ -46,6 +47,7 @@ mod crate::ir {
     type Type { #only_by_ref; }
     type Expr { #only_by_ref; }
     type Stmt { #only_by_ref; }
+    type MatchBranch { #only_by_ref; }
 
     type Rc<SourceInfo> {
         #layout(size=8, align=8);
@@ -88,9 +90,20 @@ mod crate::ir {
         fn push(&mut self, Rc<Stmt>);
     }
 
+    type Rc<MatchBranch> {
+        #layout(size=8, align=8);
+    }
+
+    type Vec<Rc<MatchBranch>> {
+        #heap_allocated;
+        fn new() -> Vec<Rc<MatchBranch>>;
+        fn push(&mut self, Rc<MatchBranch>);
+    }
+
     type Rc<Type> {
         #layout(size=8, align=8);
         fn deref(&self) -> &Type;
+        fn clone(&self) -> Rc<Type>;
     }
 
     type Rc<Ident> {
@@ -308,12 +321,15 @@ mod crate::clang {
     fn mk_lvalue_err(Rc<SourceInfo>, Rc<Type>) -> Rc<Expr>;
 
     fn mk_var_decl(Rc<SourceInfo>, Rc<Ident>, Rc<Type>) -> Rc<Stmt>;
+    fn mk_let_stmt(Rc<SourceInfo>, Rc<Ident>, Rc<Type>, Rc<Expr>) -> Rc<Stmt>;
     fn mk_decl_stack_array(Rc<SourceInfo>, Rc<Ident>, Rc<Type>, Rc<Expr>) -> Rc<Stmt>;
     fn mk_assign(Rc<SourceInfo>, Rc<Expr>, Rc<Expr>) -> Rc<Stmt>;
     fn mk_return(Rc<SourceInfo>, Rc<Expr>) -> Rc<Stmt>;
     fn mk_return_void(Rc<SourceInfo>) -> Rc<Stmt>;
     fn mk_call(Rc<SourceInfo>, Rc<Expr>) -> Rc<Stmt>;
     fn mk_if(Rc<SourceInfo>, Rc<Expr>, Vec<Rc<Stmt>>, Vec<Rc<Stmt>>, Vec<Rc<Expr>>) -> Rc<Stmt>;
+    fn mk_match_branch(Vec<Rc<Expr>>, Vec<Rc<Stmt>>) -> Rc<MatchBranch>;
+    fn mk_match(Rc<SourceInfo>, Rc<Expr>, Vec<Rc<MatchBranch>>, Vec<Rc<Stmt>>, Vec<Rc<Expr>>) -> Rc<Stmt>;
     fn mk_while(Rc<SourceInfo>, Rc<Expr>, Vec<Rc<Expr>>, Vec<Rc<Expr>>, Vec<Rc<Expr>>, Vec<Rc<Stmt>>) -> Rc<Stmt>;
     fn mk_break(Rc<SourceInfo>) -> Rc<Stmt>;
     fn mk_continue(Rc<SourceInfo>) -> Rc<Stmt>;

--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -160,6 +160,12 @@ Rc<rust::num_bigint::BigInt> toBigInt(llvm::APInt const &n) {
   return mk_bigint(toStr(out));
 }
 
+Rc<rust::num_bigint::BigInt> toBigInt(llvm::APSInt const &n) {
+  llvm::SmallString<16> out;
+  n.toString(out);
+  return mk_bigint(toStr(out));
+}
+
 struct AnonNameGen {
   llvm::StringRef base;
   unsigned i = 0;
@@ -1845,38 +1851,13 @@ public:
       auto scrutTy =
           trQualType(sw->getCond()->getType(), sw->getCond()->getSourceRange());
 
-      // Create scrutinee temp variable
+      // Bind the scrutinee once as an immutable value.
       static int switchCounter = 0;
-      auto scrutName = "__switch_scrut_" + std::to_string(switchCounter);
+      auto switchIndex = switchCounter++;
+      auto scrutName = "__switch_scrut_" + std::to_string(switchIndex);
       auto scrutId = ctx.mk_ident(toStr(scrutName), loc.clone());
-      stmts.push(mk_var_decl(loc.clone(), scrutId.clone(), std::move(scrutTy)));
-      stmts.push(mk_assign(loc.clone(),
-                           mk_lvalue_var(loc.clone(), scrutId.clone()),
-                           std::move(scrutRval)));
-
-      // Create hit and brk flag variables
-      auto hitName = "__switch_hit_" + std::to_string(switchCounter);
-      auto brkName = "__switch_brk_" + std::to_string(switchCounter);
-      switchCounter++;
-      auto hitId = ctx.mk_ident(toStr(hitName), loc.clone());
-      auto brkId = ctx.mk_ident(toStr(brkName), loc.clone());
-      auto boolTy = mk_bool_type(loc.clone());
-
-      stmts.push(
-          mk_var_decl(loc.clone(), hitId.clone(), mk_bool_type(loc.clone())));
-      stmts.push(mk_assign(loc.clone(),
-                           mk_lvalue_var(loc.clone(), hitId.clone()),
-                           mk_bool_lit(loc.clone(), false)));
-      stmts.push(
-          mk_var_decl(loc.clone(), brkId.clone(), mk_bool_type(loc.clone())));
-      stmts.push(mk_assign(loc.clone(),
-                           mk_lvalue_var(loc.clone(), brkId.clone()),
-                           mk_bool_lit(loc.clone(), false)));
-
-      // Set switchBreakId so BreakStmt sets flag
-      auto savedSwitchBreak = switchBreakId;
-      auto brkIdHeap = new Rc<ir::Ident>(brkId.clone());
-      switchBreakId = brkIdHeap;
+      stmts.push(mk_let_stmt(loc.clone(), scrutId.clone(), scrutTy.clone(),
+                             std::move(scrutRval)));
 
       // Collect cases from the switch body. A switch postcondition is used as
       // the join invariant for every desugared case test.
@@ -1894,33 +1875,8 @@ public:
       if (!comp) {
         reportUnsupported(body->getSourceRange(), loc,
                           "switch body must be a compound statement", "");
-        delete switchBreakId;
-        switchBreakId = savedSwitchBreak;
         return {};
       }
-      auto caseEnss = [&]() {
-        auto enss = Vec<Rc<ir::Expr>>::new_();
-        if (!switchEnss.empty()) {
-          auto combined = switchEnss.front().clone();
-          for (size_t i = 1; i < switchEnss.size(); i++) {
-            combined =
-                mk_rvalue_binop(loc.clone(), ir::BinOp::LogAnd(),
-                                std::move(combined), switchEnss[i].clone());
-          }
-          combined = mk_rvalue_binop(
-              loc.clone(), ir::BinOp::LogAnd(), std::move(combined),
-              mk_live(loc.clone(),
-                      mk_lvalue_var(loc.clone(), scrutId.clone())));
-          combined = mk_rvalue_binop(
-              loc.clone(), ir::BinOp::LogAnd(), std::move(combined),
-              mk_live(loc.clone(), mk_lvalue_var(loc.clone(), hitId.clone())));
-          combined = mk_rvalue_binop(
-              loc.clone(), ir::BinOp::LogAnd(), std::move(combined),
-              mk_live(loc.clone(), mk_lvalue_var(loc.clone(), brkId.clone())));
-          enss.push(std::move(combined));
-        }
-        return enss;
-      };
 
       auto containsSwitchBreak = [&](auto &self, Stmt *s) -> bool {
         if (dyn_cast<BreakStmt>(s))
@@ -1984,15 +1940,140 @@ public:
         }
       }
 
+      // A switch whose cases all end in a direct break has no fall-through.
+      // Emit it as one match and omit the terminal breaks.
+      bool hasOnlyTerminalBreaks = !groups.empty();
+      std::vector<SwitchGroup *> cases;
+      SwitchGroup *defaultGroup = nullptr;
+      for (auto &group : groups) {
+        bool hasTerminalBreak =
+            !group.body.empty() && isa<BreakStmt>(group.body.back());
+        if (!hasTerminalBreak) {
+          hasOnlyTerminalBreaks = false;
+          break;
+        }
+
+        size_t bodySize = group.body.size() - 1;
+        if (group.isDefault) {
+          defaultGroup = &group;
+        } else {
+          cases.push_back(&group);
+        }
+        for (size_t i = 0; i < bodySize; i++) {
+          if (containsSwitchBreak(containsSwitchBreak, group.body[i])) {
+            hasOnlyTerminalBreaks = false;
+            break;
+          }
+        }
+        if (!hasOnlyTerminalBreaks)
+          break;
+      }
+
+      if (hasOnlyTerminalBreaks && !cases.empty() && !switchEnss.empty()) {
+        auto makeBody = [&](SwitchGroup &group) {
+          auto bodyStmts = Vec<Rc<ir::Stmt>>::new_();
+          size_t bodySize = group.body.size() - 1;
+          for (size_t i = 0; i < bodySize; i++)
+            trStmt(bodyStmts, group.body[i]);
+          return bodyStmts;
+        };
+
+        bool canUseMatch = true;
+        for (auto *group : cases) {
+          for (auto *caseValue : group->caseValues) {
+            Expr::EvalResult result;
+            if (!caseValue->EvaluateAsInt(result, *astCtx) ||
+                !result.Val.isInt()) {
+              canUseMatch = false;
+              break;
+            }
+          }
+          if (!canUseMatch)
+            break;
+        }
+
+        if (canUseMatch) {
+          auto matchBranches = Vec<Rc<ir::MatchBranch>>::new_();
+          for (auto *group : cases) {
+            auto patterns = Vec<Rc<ir::Expr>>::new_();
+            for (auto *caseValue : group->caseValues) {
+              Expr::EvalResult result;
+              bool evaluated = caseValue->EvaluateAsInt(result, *astCtx);
+              assert(evaluated && result.Val.isInt());
+              patterns.push(mk_int_lit(getRange(caseValue->getSourceRange()),
+                                       toBigInt(result.Val.getInt()),
+                                       scrutTy.clone()));
+            }
+            matchBranches.push(
+                mk_match_branch(std::move(patterns), makeBody(*group)));
+          }
+
+          auto defaultBody = defaultGroup ? makeBody(*defaultGroup)
+                                          : Vec<Rc<ir::Stmt>>::new_();
+          auto matchEnss = Vec<Rc<ir::Expr>>::new_();
+          auto combined = switchEnss.front().clone();
+          for (size_t i = 1; i < switchEnss.size(); i++) {
+            combined =
+                mk_rvalue_binop(loc.clone(), ir::BinOp::LogAnd(),
+                                std::move(combined), switchEnss[i].clone());
+          }
+          matchEnss.push(std::move(combined));
+          stmts.push(mk_match(loc.clone(),
+                              mk_lvalue_var(loc.clone(), scrutId.clone()),
+                              std::move(matchBranches), std::move(defaultBody),
+                              std::move(matchEnss)));
+          return {};
+        }
+      }
+
+      // General switches retain explicit hit and break state to model
+      // fall-through.
+      auto hitName = "__switch_hit_" + std::to_string(switchIndex);
+      auto brkName = "__switch_brk_" + std::to_string(switchIndex);
+      auto hitId = ctx.mk_ident(toStr(hitName), loc.clone());
+      auto brkId = ctx.mk_ident(toStr(brkName), loc.clone());
+
+      stmts.push(
+          mk_var_decl(loc.clone(), hitId.clone(), mk_bool_type(loc.clone())));
+      stmts.push(mk_assign(loc.clone(),
+                           mk_lvalue_var(loc.clone(), hitId.clone()),
+                           mk_bool_lit(loc.clone(), false)));
+      stmts.push(
+          mk_var_decl(loc.clone(), brkId.clone(), mk_bool_type(loc.clone())));
+      stmts.push(mk_assign(loc.clone(),
+                           mk_lvalue_var(loc.clone(), brkId.clone()),
+                           mk_bool_lit(loc.clone(), false)));
+
+      auto savedSwitchBreak = switchBreakId;
+      switchBreakId = new Rc<ir::Ident>(brkId.clone());
+
+      auto caseEnss = [&]() {
+        auto enss = Vec<Rc<ir::Expr>>::new_();
+        if (!switchEnss.empty()) {
+          auto combined = switchEnss.front().clone();
+          for (size_t i = 1; i < switchEnss.size(); i++) {
+            combined =
+                mk_rvalue_binop(loc.clone(), ir::BinOp::LogAnd(),
+                                std::move(combined), switchEnss[i].clone());
+          }
+          combined = mk_rvalue_binop(
+              loc.clone(), ir::BinOp::LogAnd(), std::move(combined),
+              mk_live(loc.clone(), mk_lvalue_var(loc.clone(), hitId.clone())));
+          combined = mk_rvalue_binop(
+              loc.clone(), ir::BinOp::LogAnd(), std::move(combined),
+              mk_live(loc.clone(), mk_lvalue_var(loc.clone(), brkId.clone())));
+          enss.push(std::move(combined));
+        }
+        return enss;
+      };
+
       for (auto &group : groups) {
         auto childLoc = getRange(group.label->getSourceRange());
         if (!group.isDefault) {
           // Build match condition: scrut == v1 || scrut == v2 || ...
           Rc<ir::Expr> matchCond = mk_bool_lit(childLoc.clone(), false);
           for (auto *cv : group.caseValues) {
-            auto scrutRead = mk_rvalue_lvalue(
-                childLoc.clone(),
-                mk_lvalue_var(childLoc.clone(), scrutId.clone()));
+            auto scrutRead = mk_lvalue_var(childLoc.clone(), scrutId.clone());
             auto caseVal = trRValue(cv->IgnoreParenImpCasts());
             auto eq = mk_rvalue_binop(childLoc.clone(), ir::BinOp::Eq(),
                                       std::move(scrutRead), std::move(caseVal));

--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-05 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-06 "$@"

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -883,6 +883,9 @@ fn mk_lvalue_err(loc: Rc<SourceInfo>, ty: Rc<Type>) -> Rc<Expr> {
 fn mk_var_decl(loc: Rc<SourceInfo>, id: Rc<Ident>, ty: Rc<Type>) -> Rc<Stmt> {
     mk_ast(loc, StmtT::Decl(id, ty))
 }
+fn mk_let_stmt(loc: Rc<SourceInfo>, id: Rc<Ident>, ty: Rc<Type>, value: Rc<Expr>) -> Rc<Stmt> {
+    mk_ast(loc, StmtT::Let(id, ty, value))
+}
 fn mk_decl_stack_array(
     loc: Rc<SourceInfo>,
     name: Rc<Ident>,
@@ -915,6 +918,27 @@ fn mk_if(loc: Rc<SourceInfo>, cond: Rc<Expr>, a: Stmts, b: Stmts, ensures: Exprs
         cond,
         then_branch: Rc::new(a),
         else_branch: Rc::new(b),
+        ensures: Rc::new(ensures),
+    }
+    .with_loc(loc)
+}
+fn mk_match_branch(patterns: Exprs, body: Stmts) -> Rc<MatchBranch> {
+    Rc::new(MatchBranch {
+        patterns: Rc::new(patterns),
+        body: Rc::new(body),
+    })
+}
+fn mk_match(
+    loc: Rc<SourceInfo>,
+    scrutinee: Rc<Expr>,
+    branches: Vec<Rc<MatchBranch>>,
+    default_branch: Stmts,
+    ensures: Exprs,
+) -> Rc<Stmt> {
+    StmtT::Match {
+        scrutinee,
+        branches: Rc::new(branches),
+        default_branch: Rc::new(default_branch),
         ensures: Rc::new(ensures),
     }
     .with_loc(loc)

--- a/src/env.rs
+++ b/src/env.rs
@@ -274,6 +274,9 @@ impl Env {
     pub fn push_stmt(&mut self, stmt: &Stmt) {
         match &stmt.val {
             StmtT::Decl(ident, ty) => self.push_var_decl(ident, ty.clone(), LocalDeclKind::LValue),
+            StmtT::Let(ident, ty, _) => {
+                self.push_var_decl(ident, ty.clone(), LocalDeclKind::RValue)
+            }
             StmtT::DeclStackArray {
                 name, elem_type, ..
             } => {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -396,10 +396,18 @@ pub type Ident = Ast<Rc<IdentT>>;
 
 pub type Stmt = Ast<StmtT>;
 pub type Stmts = Vec<Rc<Stmt>>;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct MatchBranch {
+    pub patterns: Rc<Exprs>,
+    pub body: Rc<Stmts>,
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum StmtT {
     Call(Rc<Expr>),
     Decl(Rc<Ident>, Rc<Type>),
+    Let(Rc<Ident>, Rc<Type>, Rc<Expr>),
     DeclStackArray {
         name: Rc<Ident>,
         elem_type: Rc<Type>,
@@ -410,6 +418,12 @@ pub enum StmtT {
         cond: Rc<Expr>,
         then_branch: Rc<Stmts>,
         else_branch: Rc<Stmts>,
+        ensures: Rc<Exprs>,
+    },
+    Match {
+        scrutinee: Rc<Expr>,
+        branches: Rc<Vec<Rc<MatchBranch>>>,
+        default_branch: Rc<Stmts>,
         ensures: Rc<Exprs>,
     },
     While {

--- a/src/ir/pretty.rs
+++ b/src/ir/pretty.rs
@@ -455,6 +455,16 @@ impl PrettyIR for StmtT {
                 .append(";")
                 .nest(2)
                 .group(),
+            StmtT::Let(x, ty, value) => RcDoc::text("let ")
+                .append(x.to_doc())
+                .append(": ")
+                .append(ty.to_doc())
+                .append(" =")
+                .append(RcDoc::line())
+                .append(value.to_doc())
+                .append(";")
+                .nest(2)
+                .group(),
             StmtT::DeclStackArray {
                 name,
                 elem_type,
@@ -499,6 +509,42 @@ impl PrettyIR for StmtT {
                 .append(pretty_block(then_branch))
                 .append(" else ")
                 .append(pretty_block(else_branch))
+                .group(),
+            StmtT::Match {
+                scrutinee,
+                branches,
+                default_branch,
+                ensures,
+            } => RcDoc::text("match (")
+                .append(scrutinee.to_doc())
+                .append(")")
+                .append(RcDoc::concat(ensures.iter().map(|e| {
+                    RcDoc::line().append(
+                        RcDoc::text("_ensures(")
+                            .append(e.to_doc())
+                            .append(")")
+                            .group(),
+                    )
+                })))
+                .append(" {")
+                .append(RcDoc::concat(branches.iter().map(|branch| {
+                    RcDoc::line()
+                        .append(RcDoc::intersperse(
+                            branch.patterns.iter().map(|pattern| pattern.to_doc()),
+                            RcDoc::text(", "),
+                        ))
+                        .append(":")
+                        .append(RcDoc::line())
+                        .append(branch.body.to_doc())
+                        .nest(2)
+                })))
+                .append(RcDoc::line())
+                .append("default:")
+                .append(RcDoc::line())
+                .append(default_branch.to_doc())
+                .nest(2)
+                .append(RcDoc::line())
+                .append("}")
                 .group(),
             StmtT::While {
                 cond,

--- a/src/pass/check.rs
+++ b/src/pass/check.rs
@@ -619,6 +619,15 @@ impl<'a> Checker<'a> {
         match &stmt.val {
             StmtT::Call(rval) => self.check_rvalue(env, rval),
             StmtT::Decl(_, ty) => self.check_type(env, ty),
+            StmtT::Let(_, ty, value) => {
+                self.check_type(env, ty);
+                self.check_rvalue(env, value);
+                if self.check_types
+                    && let Some(value_ty) = self.infer_expr(env, value)
+                {
+                    self.check_type_eq(env, value_ty.into(), ty.clone().into());
+                }
+            }
             StmtT::DeclStackArray {
                 elem_type, size, ..
             } => {
@@ -647,6 +656,31 @@ impl<'a> Checker<'a> {
                 }
                 self.check_stmts(env, then_branch);
                 self.check_stmts(env, else_branch);
+            }
+            StmtT::Match {
+                scrutinee,
+                branches,
+                default_branch,
+                ensures,
+            } => {
+                self.check_rvalue(env, scrutinee);
+                let scrutinee_ty = self.infer_expr(env, scrutinee);
+                for branch in &**branches {
+                    for pattern in &*branch.patterns {
+                        self.check_rvalue(env, pattern);
+                        if self.check_types
+                            && let (Some(scrutinee_ty), Some(pattern_ty)) =
+                                (scrutinee_ty.clone(), self.infer_expr(env, pattern))
+                        {
+                            self.check_type_eq(env, pattern_ty.into(), scrutinee_ty.into());
+                        }
+                    }
+                    self.check_stmts(env, &branch.body);
+                }
+                self.check_stmts(env, default_branch);
+                for e in &**ensures {
+                    self.check_slprop(env, e);
+                }
             }
             StmtT::While {
                 cond,

--- a/src/pass/elab.rs
+++ b/src/pass/elab.rs
@@ -863,6 +863,15 @@ impl<'a> Elaborator<'a> {
         match &mut stmt.val {
             StmtT::Call(rval) => self.elab_rvalue(env, Rc::make_mut(rval), None),
             StmtT::Decl(_, ty) => self.elab_type(env, Rc::make_mut(ty)),
+            StmtT::Let(_, ty, value) => {
+                self.elab_type(env, Rc::make_mut(ty));
+                self.elab_rvalue(env, Rc::make_mut(value), Some(ty));
+                if let Ok(value_ty) = env.infer_expr(value)
+                    && !env.vtype_eq(value_ty, ty.clone().into())
+                {
+                    cast_to(value, ty.clone());
+                }
+            }
             StmtT::DeclStackArray {
                 elem_type, size, ..
             } => {
@@ -917,6 +926,24 @@ impl<'a> Elaborator<'a> {
                 self.elab_slprops(env, Rc::make_mut(ensures));
                 self.elab_stmts(env, Rc::make_mut(then_branch));
                 self.elab_stmts(env, Rc::make_mut(else_branch));
+            }
+            StmtT::Match {
+                scrutinee,
+                branches,
+                default_branch,
+                ensures,
+            } => {
+                self.elab_rvalue(env, Rc::make_mut(scrutinee), None);
+                let scrutinee_ty = env.infer_expr(scrutinee).ok();
+                for branch in Rc::make_mut(branches) {
+                    let branch = Rc::make_mut(branch);
+                    for pattern in Rc::make_mut(&mut branch.patterns) {
+                        self.elab_rvalue(env, Rc::make_mut(pattern), scrutinee_ty.as_deref());
+                    }
+                    self.elab_stmts(env, Rc::make_mut(&mut branch.body));
+                }
+                self.elab_stmts(env, Rc::make_mut(default_branch));
+                self.elab_slprops(env, Rc::make_mut(ensures));
             }
             StmtT::While {
                 cond,

--- a/src/pass/elim_cis.rs
+++ b/src/pass/elim_cis.rs
@@ -232,6 +232,7 @@ fn rewrite_stmt(env: &Env, stmt: &mut Stmt, elim: &HashMap<Rc<IdentT>, ElimUnion
     match &mut stmt.val {
         StmtT::Call(e) | StmtT::Assert(e) => rewrite_expr(env, Rc::make_mut(e), elim),
         StmtT::DeclStackArray { size, .. } => rewrite_expr(env, Rc::make_mut(size), elim),
+        StmtT::Let(_, _, value) => rewrite_expr(env, Rc::make_mut(value), elim),
         StmtT::Assign(lhs, rhs) => {
             rewrite_expr(env, Rc::make_mut(lhs), elim);
             rewrite_expr(env, Rc::make_mut(rhs), elim);
@@ -245,6 +246,25 @@ fn rewrite_stmt(env: &Env, stmt: &mut Stmt, elim: &HashMap<Rc<IdentT>, ElimUnion
             rewrite_expr(env, Rc::make_mut(cond), elim);
             rewrite_stmts(env, Rc::make_mut(then_branch), elim);
             rewrite_stmts(env, Rc::make_mut(else_branch), elim);
+            for e in Rc::make_mut(ensures).iter_mut() {
+                rewrite_expr(env, Rc::make_mut(e), elim);
+            }
+        }
+        StmtT::Match {
+            scrutinee,
+            branches,
+            default_branch,
+            ensures,
+        } => {
+            rewrite_expr(env, Rc::make_mut(scrutinee), elim);
+            for branch in Rc::make_mut(branches) {
+                let branch = Rc::make_mut(branch);
+                for pattern in Rc::make_mut(&mut branch.patterns) {
+                    rewrite_expr(env, Rc::make_mut(pattern), elim);
+                }
+                rewrite_stmts(env, Rc::make_mut(&mut branch.body), elim);
+            }
+            rewrite_stmts(env, Rc::make_mut(default_branch), elim);
             for e in Rc::make_mut(ensures).iter_mut() {
                 rewrite_expr(env, Rc::make_mut(e), elim);
             }
@@ -513,6 +533,10 @@ fn rewrite_types_stmt(stmt: &mut Stmt, elim: &HashMap<Rc<IdentT>, ElimUnion>) {
             rewrite_types_expr(Rc::make_mut(e), elim)
         }
         StmtT::Decl(_, ty) => rewrite_type(ty, elim),
+        StmtT::Let(_, ty, value) => {
+            rewrite_type(ty, elim);
+            rewrite_types_expr(Rc::make_mut(value), elim);
+        }
         StmtT::DeclStackArray {
             elem_type, size, ..
         } => {
@@ -532,6 +556,25 @@ fn rewrite_types_stmt(stmt: &mut Stmt, elim: &HashMap<Rc<IdentT>, ElimUnion>) {
             rewrite_types_expr(Rc::make_mut(cond), elim);
             rewrite_types_stmts(Rc::make_mut(then_branch), elim);
             rewrite_types_stmts(Rc::make_mut(else_branch), elim);
+            for e in Rc::make_mut(ensures).iter_mut() {
+                rewrite_types_expr(Rc::make_mut(e), elim);
+            }
+        }
+        StmtT::Match {
+            scrutinee,
+            branches,
+            default_branch,
+            ensures,
+        } => {
+            rewrite_types_expr(Rc::make_mut(scrutinee), elim);
+            for branch in Rc::make_mut(branches) {
+                let branch = Rc::make_mut(branch);
+                for pattern in Rc::make_mut(&mut branch.patterns) {
+                    rewrite_types_expr(Rc::make_mut(pattern), elim);
+                }
+                rewrite_types_stmts(Rc::make_mut(&mut branch.body), elim);
+            }
+            rewrite_types_stmts(Rc::make_mut(default_branch), elim);
             for e in Rc::make_mut(ensures).iter_mut() {
                 rewrite_types_expr(Rc::make_mut(e), elim);
             }

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -2193,6 +2193,52 @@ impl<'a> Emitter<'a> {
         self.emit_expr(env, v).to_rvalue_decayed()
     }
 
+    fn emit_pattern(&mut self, env: &Env, pattern: &Expr) -> Doc {
+        if let ExprT::IntLit(val, ty) = &pattern.val {
+            let resolved = env.vtype_whnf(ty.clone().into());
+            let literal = match resolved.val {
+                TypeT::Int {
+                    signed: true,
+                    width: 8,
+                } => Some(format!("{}y", val)),
+                TypeT::Int {
+                    signed: false,
+                    width: 8,
+                } => Some(format!("{}uy", normalize_unsigned(val, 8))),
+                TypeT::Int {
+                    signed: true,
+                    width: 16,
+                } => Some(format!("{}s", val)),
+                TypeT::Int {
+                    signed: false,
+                    width: 16,
+                } => Some(format!("{}us", normalize_unsigned(val, 16))),
+                TypeT::Int {
+                    signed: true,
+                    width: 32,
+                } => Some(format!("{}l", val)),
+                TypeT::Int {
+                    signed: false,
+                    width: 32,
+                } => Some(format!("{}ul", normalize_unsigned(val, 32))),
+                TypeT::Int {
+                    signed: true,
+                    width: 64,
+                } => Some(format!("{}L", val)),
+                TypeT::Int {
+                    signed: false,
+                    width: 64,
+                } => Some(format!("{}uL", normalize_unsigned(val, 64))),
+                TypeT::SizeT => Some(format!("{}sz", val)),
+                _ => None,
+            };
+            if let Some(literal) = literal {
+                return Doc::text(literal);
+            }
+        }
+        self.emit_rvalue(env, pattern)
+    }
+
     fn emit_rvalue_inner(&mut self, env: &Env, v: &Expr) -> Doc {
         annotated(v, || {
             match &v.val {
@@ -3614,6 +3660,18 @@ impl<'a> Emitter<'a> {
                             .group()
                     }
                 }
+                StmtT::Let(x, ty, value) => Doc::text("let ")
+                    .append(self.emit_name(Name::Var(x.val.clone())))
+                    .append(" :")
+                    .append(Doc::line())
+                    .append(self.emit_type(env, ty))
+                    .append(Doc::line())
+                    .append("=")
+                    .group()
+                    .append(Doc::line().append(self.emit_rvalue(env, value)).nest(2))
+                    .append(";")
+                    .nest(2)
+                    .group(),
                 StmtT::DeclStackArray {
                     name,
                     elem_type,
@@ -3963,6 +4021,53 @@ impl<'a> Emitter<'a> {
                         .append(else_doc)
                         .append(";")
                         .group()
+                }
+                StmtT::Match {
+                    scrutinee,
+                    branches,
+                    default_branch,
+                    ensures,
+                } => {
+                    let mut branch_docs = Vec::new();
+                    for branch in &**branches {
+                        for pattern in &*branch.patterns {
+                            branch_docs.push(
+                                Doc::line()
+                                    .append(self.emit_pattern(env, pattern))
+                                    .append(" -> ")
+                                    .append(self.emit_block(env, &branch.body))
+                                    .nest(2),
+                            );
+                        }
+                    }
+                    let match_doc = Doc::text("match ")
+                        .append(parens(self.emit_rvalue(env, scrutinee)))
+                        .append(" {")
+                        .append(Doc::concat(branch_docs))
+                        .append(Doc::line())
+                        .append("_ -> ")
+                        .append(self.emit_block(env, default_branch))
+                        .nest(2)
+                        .append(Doc::line())
+                        .append("};")
+                        .group();
+                    if ensures.is_empty() {
+                        match_doc
+                    } else {
+                        // A forward label fixes the join postcondition while
+                        // preserving the ambient stt/stt_div effect.
+                        let mut doc = block(Doc::hardline().append(match_doc));
+                        for e in ensures.iter() {
+                            doc = doc
+                                .append(Doc::hardline())
+                                .append("ensures ")
+                                .append(self.emit_rvalue(env, e));
+                        }
+                        doc.append(Doc::hardline())
+                            .append("label ")
+                            .append(self.fresh_tmp("match_join"))
+                            .append(":;")
+                    }
                 }
                 StmtT::While {
                     cond,
@@ -6747,6 +6852,74 @@ impl<'a> Emitter<'a> {
                         .group()
                         .nest(2)
                         .append(Doc::line().append(ghost_doc).nest(2))
+                        .append(Doc::line())
+                        .append("in")
+                        .append(Doc::line().append(rest).nest(2)),
+                )
+            }
+
+            StmtT::Match {
+                scrutinee,
+                branches,
+                default_branch,
+                ..
+            } => {
+                let rest = &stmts[1..];
+                let mut branch_docs = Vec::new();
+                for branch in &**branches {
+                    for pattern in &*branch.patterns {
+                        let branch_stmts = append_rest(&branch.body, rest);
+                        branch_docs.push(
+                            Doc::line()
+                                .append("| ")
+                                .append(self.emit_pattern(env, pattern))
+                                .append(" ->")
+                                .append(
+                                    Doc::line()
+                                        .append(self.emit_pure_body(env, &branch_stmts))
+                                        .nest(2),
+                                ),
+                        );
+                    }
+                }
+                parens(
+                    Doc::text("match")
+                        .append(Doc::line())
+                        .append(self.emit_rvalue(env, scrutinee))
+                        .append(Doc::line())
+                        .append("with")
+                        .append(Doc::concat(branch_docs))
+                        .append(Doc::line())
+                        .append("| _ ->")
+                        .append(
+                            Doc::line()
+                                .append(
+                                    self.emit_pure_body(env, &append_rest(default_branch, rest)),
+                                )
+                                .nest(2),
+                        ),
+                )
+            }
+
+            StmtT::Let(x, ty, value) => {
+                let value_doc = self.emit_rvalue(env, value);
+                let ty_doc = self.emit_type(env, ty);
+                let mut rest_env = env.clone();
+                rest_env.push_var_decl(x, ty.clone(), LocalDeclKind::RValue);
+                let rest = self.emit_pure_body(&rest_env, &stmts[1..]);
+                parens(
+                    Doc::text("let")
+                        .append(Doc::line())
+                        .append(self.emit_name(Name::Var(x.val.clone())))
+                        .append(Doc::line())
+                        .append(":")
+                        .append(Doc::line())
+                        .append(ty_doc)
+                        .append(Doc::line())
+                        .append("=")
+                        .group()
+                        .nest(2)
+                        .append(Doc::line().append(value_doc).nest(2))
                         .append(Doc::line())
                         .append("in")
                         .append(Doc::line().append(rest).nest(2)),

--- a/src/pass/merge.rs
+++ b/src/pass/merge.rs
@@ -634,6 +634,10 @@ fn collect_refs_stmt(s: &Stmt, out: &mut Vec<TypeKey>) {
     match &s.val {
         StmtT::Call(e) | StmtT::Assert(e) => collect_refs_expr(e, out),
         StmtT::Decl(_, ty) => collect_type_refs(ty, out),
+        StmtT::Let(_, ty, value) => {
+            collect_type_refs(ty, out);
+            collect_refs_expr(value, out);
+        }
         StmtT::DeclStackArray {
             elem_type, size, ..
         } => {
@@ -656,6 +660,24 @@ fn collect_refs_stmt(s: &Stmt, out: &mut Vec<TypeKey>) {
             }
             for st in else_branch.iter() {
                 collect_refs_stmt(st, out);
+            }
+            exprs(ensures, out);
+        }
+        StmtT::Match {
+            scrutinee,
+            branches,
+            default_branch,
+            ensures,
+        } => {
+            collect_refs_expr(scrutinee, out);
+            for branch in branches.iter() {
+                exprs(&branch.patterns, out);
+                for stmt in branch.body.iter() {
+                    collect_refs_stmt(stmt, out);
+                }
+            }
+            for stmt in default_branch.iter() {
+                collect_refs_stmt(stmt, out);
             }
             exprs(ensures, out);
         }

--- a/src/pass/prune.rs
+++ b/src/pass/prune.rs
@@ -262,6 +262,10 @@ fn scan_stmt(deps: &mut HashSet<DeclName>, stmt: &Stmt) {
     match &stmt.val {
         StmtT::Call(v) => scan_expr(deps, v),
         StmtT::Decl(_name, ty) => scan_type(deps, ty),
+        StmtT::Let(_name, ty, value) => {
+            scan_type(deps, ty);
+            scan_expr(deps, value);
+        }
         StmtT::DeclStackArray {
             elem_type, size, ..
         } => {
@@ -282,6 +286,20 @@ fn scan_stmt(deps: &mut HashSet<DeclName>, stmt: &Stmt) {
             scan_exprs(deps, ensures);
             scan_stmts(deps, then_branch);
             scan_stmts(deps, else_branch)
+        }
+        StmtT::Match {
+            scrutinee,
+            branches,
+            default_branch,
+            ensures,
+        } => {
+            scan_expr(deps, scrutinee);
+            for branch in &**branches {
+                scan_exprs(deps, &branch.patterns);
+                scan_stmts(deps, &branch.body);
+            }
+            scan_stmts(deps, default_branch);
+            scan_exprs(deps, ensures);
         }
         StmtT::While {
             cond,

--- a/test/switch_stmt/switch_stmt.c
+++ b/test/switch_stmt/switch_stmt.c
@@ -23,7 +23,7 @@ int32_t day_type(int32_t day)
     return result;
 }
 
-/* Switch with fall-through */
+/* Grouped case labels share one terminal-break branch. */
 int32_t classify(int32_t x)
     _requires(x >= 0 && x <= 3)
     _ensures(x == 0 ==> return == 10)
@@ -46,12 +46,29 @@ int32_t classify(int32_t x)
     return r;
 }
 
+/* A genuine fall-through switch retains the general switch encoding. */
+int32_t accumulate_with_fallthrough(int32_t x)
+    _requires(x == 0 || x == 1)
+    _ensures(x == 0 ==> return == 11)
+    _ensures(x == 1 ==> return == 1)
+{
+    int32_t result = 0;
+    switch (x) {
+    case 0:
+        result = 10;
+    case 1:
+        result = result + 1;
+        break;
+    }
+    return result;
+}
+
 static void write_result(int32_t* _out result)
 {
     *result = 42;
 }
 
-/* A switch join contract preserves resources across an output-writing call. */
+/* An annotated match preserves resources across a potentially divergent call. */
 int32_t call_in_case(int32_t x)
 {
     int32_t result = 0;
@@ -60,10 +77,10 @@ int32_t call_in_case(int32_t x)
         _ensures(_live(x) && _live(result))
     {
     case 0:
-        write_result(&result);
+        result = 1;
         break;
     default:
-        result = 1;
+        write_result(&result);
         break;
     }
 
@@ -80,3 +97,188 @@ int32_t classify_with_returns(int32_t x)
         return 20;
     }
 }
+
+/* Sparse terminal-break cases retain source-order C switch semantics. */
+int32_t sparse_unsorted(int32_t x)
+    _ensures(x == -10 ==> return == 1)
+    _ensures(x == 7 ==> return == 2)
+    _ensures(x == 100 ==> return == 3)
+    _ensures((x != -10 && x != 7 && x != 100) ==> return == 0)
+{
+    int32_t result = 0;
+    switch (x) {
+    case 100:
+        result = 3;
+        break;
+    case -10:
+        result = 1;
+        break;
+    case 7:
+        result = 2;
+        break;
+    }
+    return result;
+}
+
+int32_t terminal_break_i32(int32_t x)
+    _ensures(return == 0 || return == 1)
+{
+    int32_t result = 0;
+    switch (x)
+        _ensures(_live(x) && _live(result))
+        _ensures(result == 0 || result == 1)
+    {
+    case -10:
+    case 7:
+        result = 1;
+        break;
+    }
+    return result;
+}
+
+int32_t terminal_break_u32(uint32_t x)
+    _ensures(return == 0 || return == 1)
+{
+    int32_t result = 0;
+    switch (x)
+        _ensures(_live(x) && _live(result))
+        _ensures(result == 0 || result == 1)
+    {
+    case 0U:
+    case 4294967295U:
+        result = 1;
+        break;
+    }
+    return result;
+}
+
+int32_t terminal_break_promoted_u8(uint8_t x)
+    _ensures(return == 0 || return == 1)
+{
+    int32_t result = 0;
+    switch (x)
+        _ensures(_live(x) && _live(result))
+        _ensures(result == 0 || result == 1)
+    {
+    case 255:
+        result = 1;
+        break;
+    }
+    return result;
+}
+
+int32_t terminal_break_i64(int64_t x)
+    _ensures(return == 0 || return == 1)
+{
+    int32_t result = 0;
+    switch (x)
+        _ensures(_live(x) && _live(result))
+        _ensures(result == 0 || result == 1)
+    {
+    case -1LL:
+        result = 1;
+        break;
+    }
+    return result;
+}
+
+int32_t terminal_break_u64(uint64_t x)
+    _ensures(return == 0 || return == 1)
+{
+    int32_t result = 0;
+    switch (x)
+        _ensures(_live(x) && _live(result))
+        _ensures(result == 0 || result == 1)
+    {
+    case 0ULL:
+    case 18446744073709551615ULL:
+        result = 1;
+        break;
+    }
+    return result;
+}
+
+_plain const char *sparse_string_name(
+    int32_t x,
+    _plain const char *fallback)
+{
+    const char *name = fallback;
+    switch (x) {
+    case 100:
+        name = "hundred";
+        break;
+    case -10:
+        name = "negative ten";
+        break;
+    case 7:
+        name = "seven";
+        break;
+    }
+    return name;
+}
+
+#ifndef SWITCH_SCALE_BRANCHES
+#define SWITCH_SCALE_BRANCHES 16
+#endif
+
+#define SCALE_CASE() \
+    case __COUNTER__: \
+        result = 1; \
+        break;
+#define REPEAT_2(M) M() M()
+#define REPEAT_4(M) REPEAT_2(M) REPEAT_2(M)
+#define REPEAT_8(M) REPEAT_4(M) REPEAT_4(M)
+#define REPEAT_16(M) REPEAT_8(M) REPEAT_8(M)
+#define REPEAT_32(M) REPEAT_16(M) REPEAT_16(M)
+#define REPEAT_64(M) REPEAT_32(M) REPEAT_32(M)
+#define REPEAT_128(M) REPEAT_64(M) REPEAT_64(M)
+#define REPEAT_256(M) REPEAT_128(M) REPEAT_128(M)
+
+/* Standalone scaling probe for annotated terminal-break match dispatch. */
+int32_t terminal_break_scale(int32_t x)
+    _ensures(return == 0 || return == 1)
+{
+    int32_t result = 0;
+    switch (x)
+        _ensures(_live(x) && _live(result))
+        _ensures(result == 0 || result == 1)
+    {
+#if SWITCH_SCALE_BRANCHES == 4
+        REPEAT_4(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 8
+        REPEAT_8(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 12
+        REPEAT_8(SCALE_CASE)
+        REPEAT_4(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 16
+        REPEAT_16(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 24
+        REPEAT_16(SCALE_CASE)
+        REPEAT_8(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 32
+        REPEAT_32(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 64
+        REPEAT_64(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 128
+        REPEAT_128(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 192
+        REPEAT_128(SCALE_CASE)
+        REPEAT_64(SCALE_CASE)
+#elif SWITCH_SCALE_BRANCHES == 256
+        REPEAT_256(SCALE_CASE)
+#else
+#error "Unsupported SWITCH_SCALE_BRANCHES value"
+#endif
+    }
+    return result;
+}
+
+#undef REPEAT_256
+#undef REPEAT_128
+#undef REPEAT_64
+#undef REPEAT_32
+#undef REPEAT_16
+#undef REPEAT_8
+#undef REPEAT_4
+#undef REPEAT_2
+#undef SCALE_CASE


### PR DESCRIPTION
Add immutable lets and first-class matches to PAL's IR, and lower annotated terminal-break switches to direct Pulse matches over machine integers.

Use forward-label joins so match postconditions preserve the ambient stt or stt_div effect. Retain the general hit/break encoding for fall-through and unannotated switches.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>