### PR TITLE
Desugar typeof types in layout expressions

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -391,6 +391,10 @@ public:
 
     if (t.getAsString() == "size_t") {
       return mk_sizet(std::move(loc));
+    } else if (auto typeOf = dyn_cast<TypeOfType>(t)) {
+      return trQualType(typeOf->desugar(), range, liftStructs);
+    } else if (auto typeOfExpr = dyn_cast<TypeOfExprType>(t)) {
+      return trQualType(typeOfExpr->desugar(), range, liftStructs);
     } else if (auto tydef = dyn_cast<TypedefType>(t)) {
       auto id = ctx.mk_ident(toStr(tydef->getDecl()->getName()), loc.clone());
       return mk_type_typedef(std::move(loc), std::move(id));

--- a/test/sizeof/sizeof.c
+++ b/test/sizeof/sizeof.c
@@ -53,3 +53,17 @@ size_t size_of_int_array_zero(void)
 {
     return sizeof(int[0]);
 }
+
+#define ALIGN_OF(TypeOrExpression) _Alignof(__typeof__(TypeOrExpression))
+
+size_t align_of_typeof_type(void)
+    _ensures(return == _Alignof(two_ints))
+{
+    return ALIGN_OF(two_ints);
+}
+
+size_t align_of_typeof_expr(two_ints value)
+    _ensures(return == _Alignof(two_ints))
+{
+    return ALIGN_OF(value);
+}


### PR DESCRIPTION
Normalize Clang TypeOfType and TypeOfExprType nodes before lowering C types. This lets sizeof and _Alignof consume GNU __typeof__ wrappers such as SNAP_ALIGNOF without changing the source macro or its production behavior.

Cover both type-name and expression forms with translated and verified alignment regressions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>