### PR TITLE
Model fixed-width unsigned increments modulo their width

### DIFF
--- a/pulse/Pulse.Lib.C.UnaryOps.fst
+++ b/pulse/Pulse.Lib.C.UnaryOps.fst
@@ -50,46 +50,58 @@ fn pluspluspost_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn pluspluspost_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i + 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i + 1) 
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i + 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i + 1
+      else FStar.UInt8.v k == FStar.UInt.add_mod (FStar.UInt8.v _i) 1)
 {
   let j = !i;
-  i := UInt8.add j 1uy;
+  i := UInt8.add_mod j 1uy;
   j;
 }
 
 fn pluspluspost_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i + 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i + 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i + 1
+      else FStar.UInt16.v k == FStar.UInt.add_mod (FStar.UInt16.v _i) 1)
 {
   let j = !i;
-  i := UInt16.add j 1us;
+  i := UInt16.add_mod j 1us;
   j;
 }
 
 fn pluspluspost_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i + 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i + 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i + 1
+      else FStar.UInt32.v k == FStar.UInt.add_mod (FStar.UInt32.v _i) 1)
 {
   let j = !i;
-  i := UInt32.add j 1ul;
+  i := UInt32.add_mod j 1ul;
   j;
 }
 
 
 fn pluspluspost_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i + 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i + 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i + 1
+      else FStar.UInt64.v k == FStar.UInt.add_mod (FStar.UInt64.v _i) 1)
 {
   let j = !i;
-  i := UInt64.add j 1UL;
+  i := UInt64.add_mod j 1UL;
   j;
 }
 
@@ -149,42 +161,54 @@ fn pluspluspre_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn pluspluspre_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i + 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i + 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i + 1
+      else FStar.UInt8.v k == FStar.UInt.add_mod (FStar.UInt8.v _i) 1)
 {
-  i := UInt8.add !i 1uy;
+  i := UInt8.add_mod !i 1uy;
   !i;
 }
 
 fn pluspluspre_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i + 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i + 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i + 1
+      else FStar.UInt16.v k == FStar.UInt.add_mod (FStar.UInt16.v _i) 1)
 {
-  i := UInt16.add !i 1us;
+  i := UInt16.add_mod !i 1us;
   !i;
 }
 
 fn pluspluspre_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i + 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i + 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i + 1
+      else FStar.UInt32.v k == FStar.UInt.add_mod (FStar.UInt32.v _i) 1)
 {
-  i := UInt32.add !i 1ul;
+  i := UInt32.add_mod !i 1ul;
   !i;
 }
 
 
 fn pluspluspre_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i + 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i + 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i + 1
+      else FStar.UInt64.v k == FStar.UInt.add_mod (FStar.UInt64.v _i) 1)
 {
-  i := UInt64.add !i 1UL;
+  i := UInt64.add_mod !i 1UL;
   !i;
 }
 
@@ -249,46 +273,58 @@ fn minusminuspost_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn minusminuspost_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i - 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i - 1) 
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i - 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i - 1
+      else FStar.UInt8.v k == FStar.UInt.sub_mod (FStar.UInt8.v _i) 1)
 {
   let j = !i;
-  i := UInt8.sub j 1uy;
+  i := UInt8.sub_mod j 1uy;
   j;
 }
 
 fn minusminuspost_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i - 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i - 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i - 1
+      else FStar.UInt16.v k == FStar.UInt.sub_mod (FStar.UInt16.v _i) 1)
 {
   let j = !i;
-  i := UInt16.sub j 1us;
+  i := UInt16.sub_mod j 1us;
   j;
 }
 
 fn minusminuspost_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i - 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i - 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i - 1
+      else FStar.UInt32.v k == FStar.UInt.sub_mod (FStar.UInt32.v _i) 1)
 {
   let j = !i;
-  i := UInt32.sub j 1ul;
+  i := UInt32.sub_mod j 1ul;
   j;
 }
 
 
 fn minusminuspost_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i - 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i - 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i - 1
+      else FStar.UInt64.v k == FStar.UInt.sub_mod (FStar.UInt64.v _i) 1)
 {
   let j = !i;
-  i := UInt64.sub j 1UL;
+  i := UInt64.sub_mod j 1UL;
   j;
 }
 
@@ -348,42 +384,54 @@ fn minusminuspre_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn minusminuspre_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i - 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i - 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i - 1
+      else FStar.UInt8.v k == FStar.UInt.sub_mod (FStar.UInt8.v _i) 1)
 {
-  i := UInt8.sub !i 1uy;
+  i := UInt8.sub_mod !i 1uy;
   !i;
 }
 
 fn minusminuspre_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i - 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i - 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i - 1
+      else FStar.UInt16.v k == FStar.UInt.sub_mod (FStar.UInt16.v _i) 1)
 {
-  i := UInt16.sub !i 1us;
+  i := UInt16.sub_mod !i 1us;
   !i;
 }
 
 fn minusminuspre_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i - 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i - 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i - 1
+      else FStar.UInt32.v k == FStar.UInt.sub_mod (FStar.UInt32.v _i) 1)
 {
-  i := UInt32.sub !i 1ul;
+  i := UInt32.sub_mod !i 1ul;
   !i;
 }
 
 
 fn minusminuspre_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i - 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i - 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i - 1
+      else FStar.UInt64.v k == FStar.UInt.sub_mod (FStar.UInt64.v _i) 1)
 {
-  i := UInt64.sub !i 1UL;
+  i := UInt64.sub_mod !i 1UL;
   !i;
 }
 

--- a/pulse/Pulse.Lib.C.UnaryOps.fsti
+++ b/pulse/Pulse.Lib.C.UnaryOps.fsti
@@ -45,28 +45,40 @@ fn pluspluspost_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn pluspluspost_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i + 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i + 1) 
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i + 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i + 1
+      else FStar.UInt8.v k == FStar.UInt.add_mod (FStar.UInt8.v _i) 1)
 
 fn pluspluspost_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i + 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i + 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i + 1
+      else FStar.UInt16.v k == FStar.UInt.add_mod (FStar.UInt16.v _i) 1)
 
 fn pluspluspost_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i + 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i + 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i + 1
+      else FStar.UInt32.v k == FStar.UInt.add_mod (FStar.UInt32.v _i) 1)
 
 
 fn pluspluspost_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i + 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i + 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i + 1
+      else FStar.UInt64.v k == FStar.UInt.add_mod (FStar.UInt64.v _i) 1)
 
 
 fn pluspluspost_sizet (i : ref SizeT.t) (#_i: erased SizeT.t)
@@ -105,31 +117,43 @@ fn pluspluspre_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn pluspluspre_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i + 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i + 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i + 1
+      else FStar.UInt8.v k == FStar.UInt.add_mod (FStar.UInt8.v _i) 1)
 
 
 fn pluspluspre_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i + 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i + 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i + 1
+      else FStar.UInt16.v k == FStar.UInt.add_mod (FStar.UInt16.v _i) 1)
 
 
 fn pluspluspre_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i + 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i + 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i + 1
+      else FStar.UInt32.v k == FStar.UInt.add_mod (FStar.UInt32.v _i) 1)
 
 
 
 fn pluspluspre_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i + 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i + 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i + 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i + 1
+      else FStar.UInt64.v k == FStar.UInt.add_mod (FStar.UInt64.v _i) 1)
 
 
 fn pluspluspre_sizet (i : ref SizeT.t) (#_i: erased SizeT.t)
@@ -174,31 +198,43 @@ fn minusminuspost_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn minusminuspost_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i - 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i - 1) 
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i - 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i - 1
+      else FStar.UInt8.v k == FStar.UInt.sub_mod (FStar.UInt8.v _i) 1)
 
 
 fn minusminuspost_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i - 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i - 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i - 1
+      else FStar.UInt16.v k == FStar.UInt.sub_mod (FStar.UInt16.v _i) 1)
 
 
 fn minusminuspost_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i - 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i - 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i - 1
+      else FStar.UInt32.v k == FStar.UInt.sub_mod (FStar.UInt32.v _i) 1)
 
 
 
 fn minusminuspost_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i - 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i - 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i - 1
+      else FStar.UInt64.v k == FStar.UInt.sub_mod (FStar.UInt64.v _i) 1)
 
 
 fn minusminuspost_sizet (i : ref SizeT.t) (#_i: erased SizeT.t)
@@ -239,36 +275,46 @@ fn minusminuspre_int64 (i : ref Int64.t) (#_i: erased Int64.t)
 
 fn minusminuspre_uint8 (i : ref UInt8.t) (#_i: erased UInt8.t)
   requires i |-> _i
-  requires pure FStar.UInt8.(fits (v _i - 1))
   returns UInt8.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt8.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt8.v _i - 1) FStar.UInt8.n
+      then FStar.UInt8.v k == FStar.UInt8.v _i - 1
+      else FStar.UInt8.v k == FStar.UInt.sub_mod (FStar.UInt8.v _i) 1)
 
 
 fn minusminuspre_uint16 (i : ref UInt16.t) (#_i: erased UInt16.t)
   requires i |-> _i
-  requires pure FStar.UInt16.(fits (v _i - 1))
   returns UInt16.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt16.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt16.v _i - 1) FStar.UInt16.n
+      then FStar.UInt16.v k == FStar.UInt16.v _i - 1
+      else FStar.UInt16.v k == FStar.UInt.sub_mod (FStar.UInt16.v _i) 1)
 
 
 fn minusminuspre_uint32 (i : ref UInt32.t) (#_i: erased UInt32.t)
   requires i |-> _i
-  requires pure FStar.UInt32.(fits (v _i - 1))
   returns UInt32.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt32.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt32.v _i - 1) FStar.UInt32.n
+      then FStar.UInt32.v k == FStar.UInt32.v _i - 1
+      else FStar.UInt32.v k == FStar.UInt.sub_mod (FStar.UInt32.v _i) 1)
 
 
 fn minusminuspre_uint64 (i : ref UInt64.t) (#_i: erased UInt64.t)
   requires i |-> _i
-  requires pure FStar.UInt64.(fits (v _i - 1))
   returns UInt64.t
-  ensures exists* k. (i |-> k) ** pure FStar.UInt64.((v k <: int) == v _i - 1)
+  ensures exists* k. (i |-> k) **
+    pure (
+      if FStar.UInt.fits (FStar.UInt64.v _i - 1) FStar.UInt64.n
+      then FStar.UInt64.v k == FStar.UInt64.v _i - 1
+      else FStar.UInt64.v k == FStar.UInt.sub_mod (FStar.UInt64.v _i) 1)
 
 fn minusminuspre_sizet (i : ref SizeT.t) (#_i: erased SizeT.t)
   requires i |-> _i
   requires pure (v _i > 0) 
   returns SizeT.t
   ensures exists* k. (i |-> k) ** pure FStar.SizeT.((v k <: int) == v _i - 1)
-
-
 

--- a/test/compound_ops/compound_ops.c
+++ b/test/compound_ops/compound_ops.c
@@ -10,6 +10,7 @@
 
 uint32_t test_post_incr(uint32_t a)
     _requires(a < 1000)
+    _ensures(return == a + 1)
 {
     a++;
     return a;
@@ -17,6 +18,7 @@ uint32_t test_post_incr(uint32_t a)
 
 uint32_t test_pre_incr(uint32_t a)
     _requires(a < 1000)
+    _ensures(return == a + 1)
 {
     ++a;
     return a;
@@ -24,6 +26,7 @@ uint32_t test_pre_incr(uint32_t a)
 
 uint32_t test_post_decr(uint32_t a)
     _requires(a > 0)
+    _ensures(return == a - 1)
 {
     a--;
     return a;
@@ -31,6 +34,7 @@ uint32_t test_post_decr(uint32_t a)
 
 uint32_t test_pre_decr(uint32_t a)
     _requires(a > 0)
+    _ensures(return == a - 1)
 {
     --a;
     return a;
@@ -69,6 +73,38 @@ uint32_t test_u32_incr(uint32_t a)
     _requires(a < UINT32_MAX)
 {
     a++;
+    a--;
+    return a;
+}
+
+uint8_t test_u8_pre_incr_wrap(void)
+    _ensures(return == 0)
+{
+    uint8_t a = UINT8_MAX;
+    ++a;
+    return a;
+}
+
+uint16_t test_u16_post_incr_wrap(void)
+    _ensures(return == 0)
+{
+    uint16_t a = UINT16_MAX;
+    a++;
+    return a;
+}
+
+uint32_t test_u32_pre_decr_wrap(void)
+    _ensures(return == UINT32_MAX)
+{
+    uint32_t a = 0;
+    --a;
+    return a;
+}
+
+uint64_t test_u64_post_decr_wrap(void)
+    _ensures(return == UINT64_MAX)
+{
+    uint64_t a = 0;
     a--;
     return a;
 }


### PR DESCRIPTION
C defines increment and decrement of fixed-width unsigned lvalues modulo 2^N, including narrow uint8_t and uint16_t values after integer promotion and assignment conversion. Replace the false fits preconditions in all fixed-width unsigned pre/post increment and decrement helpers with UInt add_mod/sub_mod operations.

Use conditional postconditions matching the wrapping UInt arithmetic helpers: expose ordinary integer addition or subtraction when the result fits, and modular arithmetic only on overflow or underflow. Keep signed overflow checks and the abstract-width size_t helpers unchanged.

Cover exact non-wrapping reasoning and representative uint8, uint16, uint32, and uint64 wraparound cases across prefix and postfix forms.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>