### PR TITLE
Accept comparing a function pointer against null in specs

### DIFF
--- a/src/pass/elab.rs
+++ b/src/pass/elab.rs
@@ -641,6 +641,31 @@ impl<'a> Elaborator<'a> {
                             return;
                         }
                     }
+                    // A function pointer compared against null. `func_ptr` is
+                    // abstract and has no equality, so both spellings (`f == 0`
+                    // and `f == NULL`, a cast of 0) are normalized to a zero
+                    // literal at the function-pointer type; emit lowers that to
+                    // `FuncPtr.is_null`. Without this the zero keeps its
+                    // `_specint`/`void*` type and `meet_type` rejects the
+                    // comparison.
+                    if let TypeT::FnPtr { .. } = &lhs_ty.val {
+                        let rhs = Rc::make_mut(rhs);
+                        let is_null_lit = match &rhs.val {
+                            ExprT::IntLit(n, _) => **n == BigInt::ZERO,
+                            ExprT::Cast(inner, cast_ty) => {
+                                matches!(&inner.val, ExprT::IntLit(n, _) if **n == BigInt::ZERO)
+                                    && matches!(
+                                        &env.vtype_whnf(cast_ty.clone().into()).val,
+                                        TypeT::Pointer(_, _) | TypeT::FnPtr { .. }
+                                    )
+                            }
+                            _ => false,
+                        };
+                        if is_null_lit {
+                            rhs.val = ExprT::IntLit(Rc::new(BigInt::ZERO), lhs_ty.to_rc());
+                            return;
+                        }
+                    }
                     // Mixed pointer-kind equality (e.g. arrayptr == ref): the two
                     // abstract pointer types are not directly comparable, so
                     // erase both operands to raw `core_ref` addresses and compare

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -221,6 +221,24 @@ int32_t use_null_truthiness(void)
     return 0;
 }
 
+/* Null comparison in a *spec* (not just a body). `f != 0` and `f != NULL` both
+   lower to `FuncPtr.is_null`, so the postcondition follows from the
+   precondition even though the two spellings differ. */
+int32_t fp_spec_nonnull(binop f)
+    _requires(f != 0)
+    _ensures(f != NULL && return == 0)
+{
+    return 0;
+}
+
+/* Same, for the `==` direction. */
+int32_t fp_spec_null(binop f)
+    _requires(f == NULL)
+    _ensures(f == 0 && return == 0)
+{
+    return 0;
+}
+
 /* ---- calling: arities / void ---- */
 
 /* Zero-arg / `void`-return callback. */

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -223,20 +223,22 @@ int32_t use_null_truthiness(void)
 
 /* Null comparison in a *spec* (not just a body). `f != 0` and `f != NULL` both
    lower to `FuncPtr.is_null`, so the postcondition follows from the
-   precondition even though the two spellings differ. */
+   precondition even though the two spellings differ. The body returns the
+   comparison itself, which exercises the same lowering in value position; here
+   `f == NULL` is false, so the result is 0. */
 int32_t fp_spec_nonnull(binop f)
     _requires(f != 0)
     _ensures(f != NULL && return == 0)
 {
-    return 0;
+    return f == NULL;
 }
 
-/* Same, for the `==` direction. */
+/* Same, for the `==` direction; `f != 0` is false, so the result is again 0. */
 int32_t fp_spec_null(binop f)
     _requires(f == NULL)
     _ensures(f == 0 && return == 0)
 {
-    return 0;
+    return f != 0;
 }
 
 /* ---- calling: arities / void ---- */


### PR DESCRIPTION
TLDR: previously if we compare a function pointer with 0 in the spec level, the translation creates an error despite the fact that PAL correctly lowers it to a comparison with NULL, i.e. `FuncPtr.is_null`. Fixing this bug.


The BinOp::Eq null special case in elab only fired for TypeT::Pointer, so for a function pointer the zero kept its _specint type (or, for NULL, a void* cast). meet_type has no FnPtr case, so elab reported "cannot apply ==" and check re-reported it after each later pass -- three errors per spec clause, which makes main.rs emit a TranslationErrors.fst asserting False.

For the NULL spelling the output was wrong too: emit_binop has no FnPtr arm, so equality degraded to F*'s builtin = against the reference null, which fails to typecheck (Error 339). func_ptr is abstract and has no equality, so FuncPtr.is_null is the only sound lowering.

Normalize both spellings to a zero literal at the function-pointer type so they reach emit's existing (FnPtr, IntLit 0) arm. != follows from the !(.. == ..) desugaring. Pointer handling is unchanged.