### PR TITLE
Fix incorrect claim about struct-level _refine and __pred in doc

### DIFF
--- a/doc/pal_surface_syntax.md
+++ b/doc/pal_surface_syntax.md
@@ -112,7 +112,7 @@ As explained in `structs.md`, PAL auto-generates predicates for compound types. 
 | `_refine_uninit(p)`         | only when uninitialised                   |
 | `_refine_value(bind, pred)` | as `_refine`, but binding name is `bind`  |
 
-A refinement does *not* change the runtime representation. It is attached to the **type** at every site where the type appears (parameter, struct field, return value, …) and is materialised as an extra pure conjunct in any slprop emitted for a value of that type — i.e. in the implicit `pts_to` of a function parameter, in a struct's `__pred`, etc.
+A refinement does *not* change the runtime representation. It is attached to the **type** at every site where the type appears (parameter, struct field, return value, …) and is materialised as an extra pure conjunct in any slprop emitted for a value of that type — e.g. in the implicit `pts_to` of a function parameter. Whether that conjunct ends up *inside* the type's auto-generated `__pred` or *alongside* it at each use site depends on where the refinement is written: a field-level refinement is folded into the struct's `__pred` (see below), whereas a refinement on a struct or typedef declaration itself is kept separate and re-attached at every use site, leaving `struct_S__pred` unchanged (see below). Folding a record/typedef-level refinement directly into `struct_S__pred` instead is potential future work, not current behavior.
 
 **On a typedef** — the refinement fires for every use of the typedef.
 


### PR DESCRIPTION
`doc/pal_surface_syntax.md` claimed that a `_refine` refinement is always materialised inside the type's auto-generated `__pred`, using "in a struct's `__pred`" as an example. This is incorrect for refinements written on a struct or typedef *declaration* itself.

Verified by generating F* from `test/refine_struct/refine_struct.c`: `struct_b32_struct__pred` (from `struct _refine(this.x._length == 32) b32_struct`) contains only the auto-generated ownership predicate — the refinement conjunct is instead re-attached separately at each use site (confirmed in `Func_b32_arr.fsti`'s `requires`/`ensures`). This directly contradicted the doc's own correct statement a few lines further down ("`struct_S__pred` itself remains unchanged").

By contrast, a *field-level* refinement (e.g. `_refine(0 < this) int x;` on a struct field) is folded directly into the struct's `__pred` — confirmed with a small scratch reproduction.

Reworded the intro paragraph to correctly distinguish the two cases, and noted that folding a record/typedef-level refinement into `__pred` itself is potential future work, not current behavior.

Doc-only change; no code or test changes.