### PR TITLE
Add explicit erased-witness parameter to Pulse.Lib.C.FuncPtr (fixes plain-pointer callback verification) 

### DIFF
--- a/pulse/Pulse.Lib.C.FuncPtr.fsti
+++ b/pulse/Pulse.Lib.C.FuncPtr.fsti
@@ -34,19 +34,16 @@ open Pulse.Lib.C.Inhabited
 
    Every combinator above is additionally parametrized by a witness type `c`,
    with `pre`/`post` taking a `c`-typed argument and the wrapped function
-   itself taking a matching, EXPLICIT `erased c` parameter after `x:a`. This
-   lets a plain (unannotated) pointer parameter's ownership -- normally an
-   `exists* v. pts_to p v` in `requires` -- be expressed via `pre x v` for an
-   explicit `v`, instead of `exists* v. pre x v`. The distinction matters
-   because Pulse elaborates a top-level `exists*` in `requires` by opening it
-   and threading the witness as a HIDDEN implicit binder placed after `x` in
-   the function's real type, which defeats `pre_of`/`post_of`'s higher-order
-   unification (it no longer sees the flat `x:a -> stt_div b (pre x) (post x)`
-   shape it needs -- F* Error 189). Making the witness an ordinary explicit
-   parameter sidesteps this: HOU only has to solve for `pre`/`post` applied to
-   two plain bound variables (`x` and `y`), exactly as it already does for `x`
-   alone today. Ordinary function pointers with no such existential parameter
-   simply instantiate `c = unit` and pass `hide ()`.
+   taking a matching, EXPLICIT `erased c` parameter after `x:a`. This lets a
+   plain pointer parameter's ownership (normally `exists* v. pts_to p v` in
+   `requires`) be expressed as `pre x v` for an explicit `v`, instead of
+   `exists* v. pre x v`. This matters because Pulse elaborates a top-level
+   `exists*` in `requires` by opening it into a HIDDEN implicit binder after
+   `x`, which defeats `pre_of`/`post_of`'s higher-order unification (F* Error
+   189: the wrapper's type no longer has the flat `x:a -> stt_div b (pre x)
+   (post x)` shape they need). An explicit witness parameter sidesteps this.
+   Ordinary function pointers with no such parameter instantiate `c = unit`
+   and pass `hide ()`.
    ============================================================================ *)
 
 (* Abstract C function pointer: `a` is the (tupled) argument type, `b` the return
@@ -57,21 +54,15 @@ val func_ptr (a: Type0) (b: Type0) : Type0
    records whether `f` may diverge. A pure prop, so `is_valid` is a persistent
    fact threadable without touching the heap.
 
-   `pre`/`post` additionally take a caller-supplied `erased c` witness. This
-   makes any existential ownership `f`'s parameters carry (e.g. `exists* v.
-   pts_to p v` for a plain, unannotated pointer parameter) an EXPLICIT curried
-   argument of the wrapped function, rather than a witness Pulse would
-   otherwise hide as an implicit binder when it opens that `exists*` while
-   elaborating the function's own `requires` -- which is exactly what defeats
-   `pre_of`/`post_of`'s higher-order unification below (the wrapper's real
-   type no longer has the flat `x:a -> stt_div b (pre x) (post x)` shape they
-   need). `pre`/`post` themselves are free to `reveal` this witness (e.g. to
-   supply a concrete `pts_to` value); it stays un-revealed at the outer
-   `pre x y`/`post x y` application so `y` remains a bare bound variable --
-   HOU needs a genuine Miller pattern (`?pre` applied to two plain variables
-   `x`/`y`), not `?pre` applied to `reveal y` (a non-pattern application).
-   Ordinary function pointers with no such existential parameter witness
-   simply instantiate `c = unit`. *)
+   `pre`/`post` additionally take a caller-supplied `erased c` witness (see
+   the witness-type note above): this keeps any existential ownership `f`'s
+   parameters carry as an EXPLICIT curried argument, rather than a hidden
+   implicit binder Pulse would otherwise introduce -- which is what defeats
+   `pre_of`/`post_of`'s higher-order unification below. `pre`/`post` may
+   `reveal` the witness internally; it stays un-revealed at the outer
+   `pre x y`/`post x y` application so HOU sees a genuine Miller pattern
+   (`?pre` applied to plain variables `x`/`y`). Ordinary function pointers
+   with no such parameter simply instantiate `c = unit`. *)
 val valid (#a #b #c: Type0) (f: func_ptr a b) (div: bool) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop) : prop
 let is_valid (#a #b #c: Type0) ([@@@mkey] f: func_ptr a b) (div: bool) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop) : slprop = pure (valid f div pre post)
 

--- a/pulse/Pulse.Lib.C.FuncPtr.fsti
+++ b/pulse/Pulse.Lib.C.FuncPtr.fsti
@@ -31,6 +31,22 @@ open Pulse.Lib.C.Inhabited
      - is_valid      : `let`-definition, `pure (valid ..)`
      - drop_is_valid : proven `ghost fn` (just `unfold`s `is_valid` to `emp`)
      - valid_cast    : proven `ghost fn` (unfold/fold across a value equality)
+
+   Every combinator above is additionally parametrized by a witness type `c`,
+   with `pre`/`post` taking a `c`-typed argument and the wrapped function
+   itself taking a matching, EXPLICIT `erased c` parameter after `x:a`. This
+   lets a plain (unannotated) pointer parameter's ownership -- normally an
+   `exists* v. pts_to p v` in `requires` -- be expressed via `pre x v` for an
+   explicit `v`, instead of `exists* v. pre x v`. The distinction matters
+   because Pulse elaborates a top-level `exists*` in `requires` by opening it
+   and threading the witness as a HIDDEN implicit binder placed after `x` in
+   the function's real type, which defeats `pre_of`/`post_of`'s higher-order
+   unification (it no longer sees the flat `x:a -> stt_div b (pre x) (post x)`
+   shape it needs -- F* Error 189). Making the witness an ordinary explicit
+   parameter sidesteps this: HOU only has to solve for `pre`/`post` applied to
+   two plain bound variables (`x` and `y`), exactly as it already does for `x`
+   alone today. Ordinary function pointers with no such existential parameter
+   simply instantiate `c = unit` and pass `hide ()`.
    ============================================================================ *)
 
 (* Abstract C function pointer: `a` is the (tupled) argument type, `b` the return
@@ -39,14 +55,30 @@ val func_ptr (a: Type0) (b: Type0) : Type0
 
 (* `valid f div pre post`: the pointer `f` meets the spec `(pre, post)`; `div`
    records whether `f` may diverge. A pure prop, so `is_valid` is a persistent
-   fact threadable without touching the heap. *)
-val valid (#a #b: Type0) (f: func_ptr a b) (div: bool) (pre: a -> slprop) (post: a -> b -> slprop) : prop
-let is_valid (#a #b: Type0) ([@@@mkey] f: func_ptr a b) (div: bool) (pre: a -> slprop) (post: a -> b -> slprop) : slprop = pure (valid f div pre post)
+   fact threadable without touching the heap.
+
+   `pre`/`post` additionally take a caller-supplied `erased c` witness. This
+   makes any existential ownership `f`'s parameters carry (e.g. `exists* v.
+   pts_to p v` for a plain, unannotated pointer parameter) an EXPLICIT curried
+   argument of the wrapped function, rather than a witness Pulse would
+   otherwise hide as an implicit binder when it opens that `exists*` while
+   elaborating the function's own `requires` -- which is exactly what defeats
+   `pre_of`/`post_of`'s higher-order unification below (the wrapper's real
+   type no longer has the flat `x:a -> stt_div b (pre x) (post x)` shape they
+   need). `pre`/`post` themselves are free to `reveal` this witness (e.g. to
+   supply a concrete `pts_to` value); it stays un-revealed at the outer
+   `pre x y`/`post x y` application so `y` remains a bare bound variable --
+   HOU needs a genuine Miller pattern (`?pre` applied to two plain variables
+   `x`/`y`), not `?pre` applied to `reveal y` (a non-pattern application).
+   Ordinary function pointers with no such existential parameter witness
+   simply instantiate `c = unit`. *)
+val valid (#a #b #c: Type0) (f: func_ptr a b) (div: bool) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop) : prop
+let is_valid (#a #b #c: Type0) ([@@@mkey] f: func_ptr a b) (div: bool) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop) : slprop = pure (valid f div pre post)
 
 (* Drop a surplus `is_valid` back to `emp` (it is persistent). Proven, not
    axiomatized: `is_valid` unfolds to `pure`. `f` is `[@@@mkey]`, so the resource in
    context is matched by the pointer and `div`/`pre`/`post` are inferred. *)
-ghost fn drop_is_valid (#a #b: Type0) (#div: bool) (f: func_ptr a b) (pre: a -> slprop) (post: a -> b -> slprop)
+ghost fn drop_is_valid (#a #b #c: Type0) (#div: bool) (f: func_ptr a b) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
   requires is_valid f div pre post
   ensures emp
 {
@@ -56,7 +88,7 @@ ghost fn drop_is_valid (#a #b: Type0) (#div: bool) (f: func_ptr a b) (pre: a -> 
 (* Move `is_valid` across a provable value equality `f == g`. Needed to call
    through a pointer read back from an array slot, where the read value is only
    provably (not syntactically) equal to the stored `of_fn ..`. *)
-ghost fn valid_cast (#a #b: Type0) (#div: bool) (#pre: a -> slprop) (#post: a -> b -> slprop)
+ghost fn valid_cast (#a #b #c: Type0) (#div: bool) (#pre: a -> erased c -> slprop) (#post: a -> erased c -> b -> slprop)
   (f g: func_ptr a b)
   requires is_valid f div pre post ** pure (f == g)
   ensures is_valid g div pre post
@@ -68,47 +100,49 @@ ghost fn valid_cast (#a #b: Type0) (#div: bool) (#pre: a -> slprop) (#post: a ->
 
 (* Recover a function's pre/post directly from its *type*. PAL emits each `__fp`
    wrapper with its contract inlined into `requires`/`ensures`, so the wrapper's
-   type is `x:a -> stt[_div] b (pre x) (fun r -> post x r)`; these projectors let
-   `of_fn`/`is_valid`/`call`/`weaken` name that pre/post without a separate `let`.
-   `pre`/`post` are inferred (as lambdas) from the applied function's type;
-   `pulse_eager_unfold` reduces `pre_of f` back to that lambda so slprop matching
-   still connects. Divergent (`stt_div`) and total (`stt`) variants are distinct
-   because the function value's effect differs. *)
+   type is `x:a -> y:erased c -> stt[_div] b (pre x y) (fun r -> post x y r)`
+   (`y` is an explicit erased parameter, curried after `x`, carrying whatever
+   witness the parameters' ownership needs -- see `valid` above); these
+   projectors let `of_fn`/`is_valid`/`call`/`weaken` name that pre/post without a
+   separate `let`. `pre`/`post` are inferred (as lambdas) from the applied
+   function's type; `pulse_eager_unfold` reduces `pre_of f` back to that lambda
+   so slprop matching still connects. Divergent (`stt_div`) and total (`stt`)
+   variants are distinct because the function value's effect differs. *)
 [@@pulse_eager_unfold]
-unfold let pre_of (#a #b: Type0) (#pre: a -> slprop) (#post: a -> b -> slprop)
-  (f: (x:a -> stt_div b (pre x) (fun r -> post x r))) : (a -> slprop) = pre
+unfold let pre_of (#a #b #c: Type0) (#pre: a -> erased c -> slprop) (#post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt_div b (pre x y) (fun r -> post x y r))) : (a -> erased c -> slprop) = pre
 [@@pulse_eager_unfold]
-unfold let post_of (#a #b: Type0) (#pre: a -> slprop) (#post: a -> b -> slprop)
-  (f: (x:a -> stt_div b (pre x) (fun r -> post x r))) : (a -> b -> slprop) = post
+unfold let post_of (#a #b #c: Type0) (#pre: a -> erased c -> slprop) (#post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt_div b (pre x y) (fun r -> post x y r))) : (a -> erased c -> b -> slprop) = post
 [@@pulse_eager_unfold]
-unfold let pre_of_tot (#a #b: Type0) (#pre: a -> slprop) (#post: a -> b -> slprop)
-  (f: (x:a -> stt b (pre x) (fun r -> post x r))) : (a -> slprop) = pre
+unfold let pre_of_tot (#a #b #c: Type0) (#pre: a -> erased c -> slprop) (#post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt b (pre x y) (fun r -> post x y r))) : (a -> erased c -> slprop) = pre
 [@@pulse_eager_unfold]
-unfold let post_of_tot (#a #b: Type0) (#pre: a -> slprop) (#post: a -> b -> slprop)
-  (f: (x:a -> stt b (pre x) (fun r -> post x r))) : (a -> b -> slprop) = post
+unfold let post_of_tot (#a #b #c: Type0) (#pre: a -> erased c -> slprop) (#post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt b (pre x y) (fun r -> post x y r))) : (a -> erased c -> b -> slprop) = post
 
 (* The null function pointer. *)
 val null (a b: Type0) : func_ptr a b
 
 (* Reflect a concrete TOTAL Pulse function as a pointer. pre/post are explicit to
    avoid higher-order-unification failures. *)
-val of_fn (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
-  (f: (x:a -> stt b (pre x) (fun r -> post x r))) : func_ptr a b
+val of_fn (#a #b #c: Type0) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt b (pre x y) (fun r -> post x y r))) : func_ptr a b
 
 (* Ghost step yielding `is_valid (of_fn ..) false ..`: `of_fn` is valid, at its own
    spec, as a total pointer. *)
-val of_fn_valid (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
-  (f: (x:a -> stt b (pre x) (fun r -> post x r)))
+val of_fn_valid (#a #b #c: Type0) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt b (pre x y) (fun r -> post x y r)))
   : stt_ghost unit emp_inames emp (fun _ -> is_valid (of_fn pre post f) false pre post)
 
 (* Reflect a concrete POSSIBLY-DIVERGENT Pulse function as a pointer. *)
-val of_fn_div (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
-  (f: (x:a -> stt_div b (pre x) (fun r -> post x r))) : func_ptr a b
+val of_fn_div (#a #b #c: Type0) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt_div b (pre x y) (fun r -> post x y r))) : func_ptr a b
 
 (* Ghost step yielding `is_valid (of_fn_div ..) true ..`: `of_fn_div` is valid, at
    its own spec, as a divergent pointer. *)
-val of_fn_div_valid (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
-  (f: (x:a -> stt_div b (pre x) (fun r -> post x r)))
+val of_fn_div_valid (#a #b #c: Type0) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (f: (x:a -> y:erased c -> stt_div b (pre x y) (fun r -> post x y r)))
   : stt_ghost unit emp_inames emp (fun _ -> is_valid (of_fn_div pre post f) true pre post)
 
 (* Transfer validity across a spec weakening and/or a divergence relaxation: given
@@ -116,31 +150,34 @@ val of_fn_div_valid (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
    post, `is_valid` moves from `(div, pre, post)` to `(div', pre', post')`. The
    refinement `div ==> div'` permits total->divergent (a total pointer is trivially
    a valid divergent one) but forbids the unsound divergent->total. *)
-val weaken (#a #b: Type0) (f: func_ptr a b)
+val weaken (#a #b #c: Type0) (f: func_ptr a b)
   (div: bool) (div': bool { div ==> div' })
-  (pre: a -> slprop) (post: a -> b -> slprop)
-  (pre': a -> slprop) (post': a -> b -> slprop)
-  (wpre:  (x:a -> stt_ghost unit emp_inames (pre' x) (fun _ -> pre x)))
-  (wpost: (x:a -> y:b -> stt_ghost unit emp_inames (post x y) (fun _ -> post' x y)))
+  (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (pre': a -> erased c -> slprop) (post': a -> erased c -> b -> slprop)
+  (wpre:  (x:a -> y:erased c -> stt_ghost unit emp_inames (pre' x y) (fun _ -> pre x y)))
+  (wpost: (x:a -> y:erased c -> r:b -> stt_ghost unit emp_inames (post x y r) (fun _ -> post' x y r)))
   : stt_ghost unit emp_inames
       (is_valid f div pre post)
       (fun _ -> (is_valid f div' pre' post'))
 
-(* Indirect call of a TOTAL pointer: consume `is_valid f false pre post ** pre x`.
-   pre/post are explicit (SMT will not solve the higher-order metavariables). The
-   post also RETURNS `is_valid f false pre post` (validity is persistent), so a
-   caller can thread it across the call; callers that do not need it drop the
-   surplus. Returns `stt` -- usable from any (total or divergent) context. *)
-val call (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
-  (f: func_ptr a b)  (x: a)
-  : stt b (is_valid f false pre post  ** pre x) (fun r -> is_valid f false pre post ** post x r)
+(* Indirect call of a TOTAL pointer: consume `is_valid f false pre post ** pre x
+   w`. pre/post are explicit (SMT will not solve the higher-order
+   metavariables); the caller supplies the witness `w` explicitly (`hide ()` for
+   an ordinary, unwitnessed pointer, or the erased current value(s) it holds for
+   any plain pointer parameter otherwise). The post also RETURNS `is_valid f
+   false pre post` (validity is persistent), so a caller can thread it across
+   the call; callers that do not need it drop the surplus. Returns `stt` --
+   usable from any (total or divergent) context. *)
+val call (#a #b #c: Type0) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (f: func_ptr a b)  (x: a) (w: erased c)
+  : stt b (is_valid f false pre post  ** pre x w) (fun r -> is_valid f false pre post ** post x w r)
 
 (* Indirect call of a POSSIBLY-DIVERGENT pointer: as `call`, but keyed on
    `is_valid f true ..` and returning `stt_div`, so it lives in the divergent
    effect (and can only be used from a `divergent` body). *)
-val call_div (#a #b: Type0) (pre: a -> slprop) (post: a -> b -> slprop)
-  (f: func_ptr a b)  (x: a)
-  : stt_div b (is_valid f true pre post  ** pre x) (fun r -> is_valid f true pre post ** post x r)
+val call_div (#a #b #c: Type0) (pre: a -> erased c -> slprop) (post: a -> erased c -> b -> slprop)
+  (f: func_ptr a b)  (x: a) (w: erased c)
+  : stt_div b (is_valid f true pre post  ** pre x w) (fun r -> is_valid f true pre post ** post x w r)
 
 (* Decidable null test, for C `if (fp)` / `fp == NULL`. *)
 val is_null (#a #b: Type0) (f: func_ptr a b) : (r: bool { r <==> f == null a b })

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -3236,13 +3236,12 @@ impl<'a> Emitter<'a> {
                     // uses to build the callee wrapper's own witness tuple.
                     // Ordinary (non-witnessing) call sites pass `hide ()`.
                     //
-                    // NOTE: when the callee itself is read through the SAME
-                    // pointer (`self->field(self, ..)`), the struct
-                    // field-getter's own implicit unfold currently opens an
-                    // existential independent of this witness read, which
-                    // Pulse cannot unify automatically -- a known limitation
-                    // for self-dispatch call sites, tracked separately from
-                    // the plain-pointer-*parameter* fix this change targets.
+                    // NOTE: self-dispatch (`self->field(self, ..)`) verifies
+                    // when `self` is `_consumes` -- see `destroy_via_field` in
+                    // test/func_pointer/func_pointer.c. With a borrowed
+                    // `self`, the field getter's own unfold and this witness
+                    // read open two independent existentials for the same
+                    // value that Pulse can't unify.
                     let param_tys: Option<Vec<Rc<Type>>> = env
                         .infer_expr(f)
                         .ok()
@@ -6472,18 +6471,15 @@ impl<'a> Emitter<'a> {
         let mut requires_props: Vec<Doc> = vec![];
         let mut ensures_props: Vec<Doc> = vec![];
         let mut preserves_props: Vec<Doc> = vec![];
-        // Requires-side existential ownership groups, one per Regular/
-        // Consumed/Out arg contributing bindings (e.g. a plain pointer
-        // parameter's pointee value). Deferred until after this loop: their
-        // combined bindings become components of ONE explicit `y_fp: erased c`
-        // wrapper parameter (via `wrap_witness`) instead of independent
-        // `exists*`s, each of which Pulse would otherwise open into a hidden
-        // implicit binder placed after the wrapper's `x_fp` parameter --
-        // defeating `pre_of`/`post_of`'s higher-order unification (F* Error
-        // 189; see `Pulse.Lib.C.FuncPtr.fsti`'s witness-parameter doc). An
-        // `ensures`-side `exists*` is not part of the wrapper's own arrow
-        // *type* (it lives inside the `stt_div` RESULT slprop), so it is not a
-        // HOU obstacle and keeps using the ordinary `wrap_exists` unchanged.
+        // Requires-side existential ownership groups (e.g. a plain pointer
+        // parameter's pointee value), one per Regular/Consumed/Out arg.
+        // Deferred until after this loop: their bindings are combined into
+        // ONE explicit `y_fp: erased c` wrapper parameter (via
+        // `wrap_witness`) instead of independent `exists*`s, which Pulse
+        // would otherwise open as hidden implicit binders and break
+        // `pre_of`/`post_of`'s higher-order unification (F* Error 189; see
+        // `Pulse.Lib.C.FuncPtr.fsti`). Ensures-side `exists*`s aren't part of
+        // the wrapper's arrow type, so they keep using `wrap_exists`.
         let mut req_witness_groups: Vec<(Vec<ExBinding>, Vec<Doc>)> = vec![];
         for (n, arg) in arg_names.iter().zip(decl.args.iter()) {
             match arg.mode {

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -190,6 +190,10 @@ struct FnPtrSpecCore {
     wrap_name: Doc,
     callee: Doc,
     domain: Doc,
+    /// The type `c` of the wrapper's explicit `y_fp: erased c` witness
+    /// parameter (see `Pulse.Lib.C.FuncPtr.fsti`'s witness-parameter doc);
+    /// `unit` when no parameter needs one.
+    witness_domain: Doc,
     ret_name: Doc,
     ret_ty_doc: Doc,
     projs: Vec<Doc>,
@@ -725,6 +729,69 @@ fn fnptr_domain_doc(arg_docs: Vec<Doc>) -> Doc {
         0 => Doc::text("unit"),
         1 => arg_docs.into_iter().next().unwrap(),
         _ => parens(Doc::intersperse(arg_docs, Doc::text(" & "))),
+    }
+}
+
+/// The projection expression for extracting component `i` (0-indexed) out of
+/// an `n`-ary flat tuple value `base`, matching `fnptr_domain_doc`'s tupling
+/// convention (bare value at arity 1, `fst`/`snd` at arity 2, `MktupleN?._i`
+/// field projectors at arity >= 3 -- NOT nested `tuple2`s).
+fn nary_tuple_proj(base: Doc, i: usize, n: usize) -> Doc {
+    if n <= 1 {
+        return base;
+    }
+    if n == 2 {
+        let mut e = base;
+        for _ in 0..i {
+            e = parens(Doc::text("snd ").append(e));
+        }
+        if i < n - 1 {
+            e = parens(Doc::text("fst ").append(e));
+        }
+        return e;
+    }
+    parens(Doc::text(format!("Mktuple{n}?._{} ", i + 1)).append(base))
+}
+
+/// Like `wrap_exists`, but instead of introducing a fresh `exists* v1 v2. ..`
+/// binder for `bindings`, binds each name via `let vi = <proj_i> in ..` to a
+/// caller-supplied projection expression (one projection per binding, in
+/// order). Used for a wrapper's `requires`-side existential parameter
+/// ownership: turning it into `let`s (rather than an `exists*`) keeps it out
+/// of the wrapper's own elaborated *type*, so `pre_of`/`post_of`'s
+/// higher-order unification isn't defeated by a Pulse-inserted hidden
+/// implicit binder (see `Pulse.Lib.C.FuncPtr.fsti`'s witness-parameter doc).
+fn wrap_witness(bindings: &[ExBinding], props: Vec<Doc>, projs: &[Doc]) -> Doc {
+    let star = mk_star(props);
+    if bindings.is_empty() {
+        return star;
+    }
+    let let_prefix = Doc::concat(bindings.iter().zip(projs.iter()).map(|(b, proj)| {
+        Doc::text("let ")
+            .append(b.name.clone())
+            .append(" = ")
+            .append(proj.clone())
+            .append(" in")
+            .append(Doc::hardline())
+    }));
+    let_prefix.append(star)
+}
+
+/// If `ty` is a bare (non-`_plain`, non-`_core_ref`, non-`_nullable`) pointer
+/// type, return its pointee type -- this is exactly the pointer shape whose
+/// ownership `emit_fnptr_spec_core` witnesses via an explicit `erased c`
+/// wrapper parameter (see `Pulse.Lib.C.FuncPtr.fsti`'s witness-parameter
+/// doc). Used at `FnPtrCall` call sites (from the callee's static `FnPtr`
+/// argument types alone) to determine, in argument order, which call
+/// arguments contribute a witness component.
+fn fnptr_witness_pointee(ty: &Rc<Type>) -> Option<Rc<Type>> {
+    match &ty.val {
+        TypeT::Refine(inner, _)
+        | TypeT::RefineAlways(inner, _)
+        | TypeT::RefineUninit(inner, _)
+        | TypeT::RefineValue(inner, ..) => fnptr_witness_pointee(inner),
+        TypeT::Pointer(pointee, PointerKind::Ref | PointerKind::Unknown) => Some(pointee.clone()),
+        _ => None,
     }
 }
 
@@ -3161,12 +3228,57 @@ impl<'a> Emitter<'a> {
                     } else {
                         "Pulse.Lib.C.FuncPtr.call_div"
                     };
+                    // The explicit `w: erased c` witness argument (see
+                    // `Pulse.Lib.C.FuncPtr.fsti`): one component per bare
+                    // (non-`_plain`/non-`_core_ref`) pointer argument, holding
+                    // that pointee's CURRENT value (`hide !arg`), matching the
+                    // same argument-order convention `emit_fnptr_spec_core`
+                    // uses to build the callee wrapper's own witness tuple.
+                    // Ordinary (non-witnessing) call sites pass `hide ()`.
+                    //
+                    // NOTE: when the callee itself is read through the SAME
+                    // pointer (`self->field(self, ..)`), the struct
+                    // field-getter's own implicit unfold currently opens an
+                    // existential independent of this witness read, which
+                    // Pulse cannot unify automatically -- a known limitation
+                    // for self-dispatch call sites, tracked separately from
+                    // the plain-pointer-*parameter* fix this change targets.
+                    let param_tys: Option<Vec<Rc<Type>>> = env
+                        .infer_expr(f)
+                        .ok()
+                        .map(|t| env.vtype_whnf(t))
+                        .and_then(|t| match &t.val {
+                            TypeT::FnPtr { args, .. } => Some(args.clone()),
+                            _ => None,
+                        });
+                    let witness_vals: Vec<Doc> = param_tys
+                        .iter()
+                        .flatten()
+                        .zip(args.iter())
+                        .filter(|(ty, _)| fnptr_witness_pointee(ty).is_some())
+                        .map(|(_, a)| {
+                            let derefed = ExprT::Deref(a.clone()).with_loc(a.loc.clone());
+                            self.emit_rvalue(env, &derefed)
+                        })
+                        .collect();
+                    let witness_arg = match witness_vals.len() {
+                        0 => Doc::text("(hide ())"),
+                        1 => parens(
+                            Doc::text("hide ")
+                                .append(parens(witness_vals.into_iter().next().unwrap())),
+                        ),
+                        _ => parens(
+                            Doc::text("hide ")
+                                .append(parens(Doc::intersperse(witness_vals, Doc::text(", ")))),
+                        ),
+                    };
                     parens(naryfn([
                         Doc::text(call_prim),
                         Doc::text("_"),
                         Doc::text("_"),
                         callee_val,
                         arg_tuple,
+                        witness_arg,
                     ]))
                 }
                 ExprT::Live(v) => {
@@ -6335,22 +6447,7 @@ impl<'a> Emitter<'a> {
         let projs: Vec<Doc> = {
             let n = name_docs.len();
             (0..n)
-                .map(|i| {
-                    if n == 1 {
-                        return Doc::text("x_fp");
-                    }
-                    if n == 2 {
-                        let mut e = Doc::text("x_fp");
-                        for _ in 0..i {
-                            e = parens(Doc::text("snd ").append(e));
-                        }
-                        if i < n - 1 {
-                            e = parens(Doc::text("fst ").append(e));
-                        }
-                        return e;
-                    }
-                    parens(Doc::text(format!("Mktuple{n}?._{} x_fp", i + 1)))
-                })
+                .map(|i| nary_tuple_proj(Doc::text("x_fp"), i, n))
                 .collect()
         };
 
@@ -6375,6 +6472,19 @@ impl<'a> Emitter<'a> {
         let mut requires_props: Vec<Doc> = vec![];
         let mut ensures_props: Vec<Doc> = vec![];
         let mut preserves_props: Vec<Doc> = vec![];
+        // Requires-side existential ownership groups, one per Regular/
+        // Consumed/Out arg contributing bindings (e.g. a plain pointer
+        // parameter's pointee value). Deferred until after this loop: their
+        // combined bindings become components of ONE explicit `y_fp: erased c`
+        // wrapper parameter (via `wrap_witness`) instead of independent
+        // `exists*`s, each of which Pulse would otherwise open into a hidden
+        // implicit binder placed after the wrapper's `x_fp` parameter --
+        // defeating `pre_of`/`post_of`'s higher-order unification (F* Error
+        // 189; see `Pulse.Lib.C.FuncPtr.fsti`'s witness-parameter doc). An
+        // `ensures`-side `exists*` is not part of the wrapper's own arrow
+        // *type* (it lives inside the `stt_div` RESULT slprop), so it is not a
+        // HOU obstacle and keeps using the ordinary `wrap_exists` unchanged.
+        let mut req_witness_groups: Vec<(Vec<ExBinding>, Vec<Doc>)> = vec![];
         for (n, arg) in arg_names.iter().zip(decl.args.iter()) {
             match arg.mode {
                 ParamMode::Regular | ParamMode::Consumed => {
@@ -6396,15 +6506,10 @@ impl<'a> Emitter<'a> {
                     );
                     drop(naming);
                     if !type_props.is_empty() {
-                        let wrapped = wrap_exists(&type_bindings, type_props);
-                        match arg.mode {
-                            ParamMode::Regular => {
-                                requires_props.push(wrapped.clone());
-                                ensures_props.push(wrapped);
-                            }
-                            ParamMode::Consumed => requires_props.push(wrapped),
-                            _ => unreachable!(),
+                        if let ParamMode::Regular = arg.mode {
+                            ensures_props.push(wrap_exists(&type_bindings, type_props.clone()));
                         }
+                        req_witness_groups.push((type_bindings, type_props));
                     }
                 }
                 ParamMode::Const => {
@@ -6444,7 +6549,7 @@ impl<'a> Emitter<'a> {
                     );
                     drop(naming);
                     if !uninit_props.is_empty() {
-                        requires_props.push(wrap_exists(&uninit_bindings, uninit_props));
+                        req_witness_groups.push((uninit_bindings, uninit_props));
                     }
                     let mut type_bindings = vec![];
                     let mut type_props = vec![];
@@ -6467,6 +6572,35 @@ impl<'a> Emitter<'a> {
                         ensures_props.push(wrap_exists(&type_bindings, type_props));
                     }
                 }
+            }
+        }
+        // Combine every requires-side existential group's bindings (in arg
+        // order) into a single flat witness type tuple `c`, and re-express
+        // each group's props via `let`s projecting out of ONE explicit
+        // `y_fp: erased c` wrapper parameter (see comment above).
+        let witness_count: usize = req_witness_groups.iter().map(|(b, _)| b.len()).sum();
+        let witness_ty_docs: Vec<Doc> = req_witness_groups
+            .iter()
+            .flat_map(|(b, _)| b.iter().map(|eb| eb.ty.clone()))
+            .collect();
+        let witness_domain = fnptr_domain_doc(witness_ty_docs);
+        {
+            let witness_base = parens(Doc::text("reveal y_fp"));
+            let mut widx = 0usize;
+            for (bindings, props) in req_witness_groups {
+                if bindings.is_empty() {
+                    requires_props.push(mk_star(props));
+                    continue;
+                }
+                let group_projs: Vec<Doc> = bindings
+                    .iter()
+                    .map(|_| {
+                        let p = nary_tuple_proj(witness_base.clone(), widx, witness_count);
+                        widx += 1;
+                        p
+                    })
+                    .collect();
+                requires_props.push(wrap_witness(&bindings, props, &group_projs));
             }
         }
         // `preserves` (const params) hold across the call, so they belong in
@@ -6562,6 +6696,7 @@ impl<'a> Emitter<'a> {
             wrap_name,
             callee,
             domain,
+            witness_domain,
             ret_name,
             ret_ty_doc,
             projs,
@@ -6578,6 +6713,7 @@ impl<'a> Emitter<'a> {
             wrap_name,
             callee,
             domain,
+            witness_domain,
             ret_name,
             ret_ty_doc,
             projs,
@@ -6588,10 +6724,19 @@ impl<'a> Emitter<'a> {
         } else {
             "divergent fn "
         };
+        // `y_fp: erased c`: an explicit (not merely implicit) witness
+        // parameter for any bare pointer parameter's ownership, so
+        // `pre_of`/`post_of` see the wrapper's real type as a flat
+        // `x:a -> y:erased c -> stt_div b (pre x y) (post x y)` -- see
+        // `Pulse.Lib.C.FuncPtr.fsti`. Unconditionally present (even as a
+        // trivial `erased unit` when no witness is needed) so `of_fn`/
+        // `of_fn_div`/`call`/`call_div` share one uniform shape.
         let wrap_sig = Doc::text(wrap_kw)
             .append(wrap_name.clone())
             .append(" (x_fp: ")
             .append(domain.clone())
+            .append(") (y_fp: erased ")
+            .append(witness_domain)
             .append(")")
             .append(Doc::hardline())
             .append("  requires ")

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -1044,16 +1044,12 @@ int32_t weaken_total_to_div(void)
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
 
-/* Plain pointer parameter, no workaround annotations: PAL's auto-generated
-   ownership for `int *p` is `exists* v. pts_to p v`. Taking `touch`'s
-   address forces a `__fp` wrapper whose contract must be recovered via
-   `pre_of`/`post_of` type-reflection. This now VERIFIES: `pre`/`post`
-   (`Pulse.Lib.C.FuncPtr.fsti`) take an extra explicit `erased c` witness
-   parameter after the wrapper's own argument, so the wrapper's real type is
-   the flat `x:a -> y:erased c -> stt_div b (pre x y) (post x y)`
-   `pre_of`/`post_of` need -- the pointee's ownership is threaded through `y`
-   instead of a hidden implicit binder Pulse would otherwise introduce by
-   opening a top-level `exists*` (which is what broke HOU with Error 189). */
+/* Plain pointer parameter, no workaround annotations. Taking `touch`'s
+   address forces a `__fp` wrapper recovered via `pre_of`/`post_of`
+   type-reflection. Now VERIFIES: `pre_of`/`post_of` take an explicit
+   `erased c` witness parameter, so the wrapper's ownership is threaded
+   through it instead of a hidden implicit binder (which broke HOU with
+   Error 189). */
 void touch(int *p)
 {
 }
@@ -1063,18 +1059,16 @@ void use_touch_fp(void)
     void (*cb)(int *) = touch;
 }
 
-/* `struct itemx` itself verifies fine here -- `destroy`'s field type stays a
-   plain, non-recursive `func_ptr (ref struct_itemx) unit`, no self-
-   reference, no strict-positivity Error 3. */
+/* `struct itemx` verifies fine: `destroy`'s field type is a plain,
+   non-recursive `func_ptr`, no self-reference, no strict-positivity error. */
 struct itemx {
     void (*destroy)(struct itemx *self);
     unsigned int n;
 };
 
-/* Now VERIFIES. `destroy_impl`'s `self` is `_consumes _allocated`: a real
-   destructor that takes ownership of its receiver and frees it, rather than
-   merely borrowing it (same annotation combo as `test/dpe/DPE.c`'s
-   `destroy_uds_context`). */
+/* `destroy_impl`'s `self` is `_consumes _allocated`: a real destructor that
+   takes ownership of its receiver and frees it (same combo as
+   `test/dpe/DPE.c`'s `destroy_uds_context`). */
 void destroy_impl(_consumes _allocated struct itemx *self)
 {
     free(self);
@@ -1097,46 +1091,40 @@ _refine_value(itemx_val vo, _inline_pulse(Itemx_spec.itemx_valid $(this) $(vo)))
 _plain
 typedef struct itemx *itemx_ptr;
 
-/* Self-dispatch through a field now VERIFIES too, once `self` is
-   `_consumes`, resolving the earlier "two independent existentials for the
-   same value" mismatch (Error 228: `is_valid val_p_0... ` vs
-   `is_valid _val_self_0XX...`) documented as a known limitation before this
-   change. With a plain (borrowed, non-consuming) `self`, the call site's
-   witness computation (`hide (!(!p))`, needed to instantiate `destroy_impl`'s
-   `erased c` parameter) and the field-getter's own unfold of `p->destroy`
-   each independently opened the struct's `pts_to` existential, producing
-   two different bound names for what is semantically the same value, which
-   Pulse could not unify. With `_consumes itemx_ptr p`, `p`'s OWN top-level
-   existential (`val_p_0`, bound once by `destroy_via_field`'s `requires`)
-   is the SAME name both the field-getter and the witness computation read
-   from -- there is no second, independently-opened existential to clash
-   with, since consuming `p` up front (rather than borrowing through a
-   pointer indirection) means both projections happen against one and the
-   same already-opened value. The `itemx_valid` predicate now also asserts
-   `freeable this`, so consuming `p` yields both the `is_valid` fact needed
-   to dispatch through the field and the `freeable` fact `destroy_impl`
-   needs to physically `free` the struct. An explicit `drop_is_valid` is
-   needed at the end since `is_valid` is a non-affine fact left over after
-   the call. */
+/* Self-dispatch through a field VERIFIES once `self` is `_consumes`. With a
+   borrowed `self`, the call-site witness read (`!(!p)`) and the field
+   getter's own unfold of `p->destroy` each opened a separate existential
+   for the same value, which Pulse couldn't unify (Error 228). Consuming `p`
+   binds ONE top-level existential that both projections read from, so
+   there's no second name to clash with. `itemx_valid` also asserts
+   `freeable this`, giving `destroy_impl` the fact it needs to `free`.
+   `drop_is_valid` clears the leftover non-affine `is_valid` fact. */
 void destroy_via_field(_consumes itemx_ptr p) {
     p->destroy(p);
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
 
-/* `it` must be heap-allocated (`malloc`, not the stack) so `free` inside
-   `destroy_impl` is valid. Like the earlier stack-allocated version, a
-   freshly-`malloc`'d struct pointer still needs an explicit
-   `$unfold-uninit` to expose its per-field uninitialized cells before the
-   individual field writes below -- `malloc` gives genuinely uninitialized
-   memory (unlike `test/vec_fam/vec_fam.c`'s `calloc`-based `vec_new`, whose
-   zeroed memory can be treated as already-initialized field values). */
-void use_destroy_via_field(void)
+/* Constructs a valid `struct itemx` and RETURNS it (as `itemx_ptr`), instead
+   of consuming it immediately in the same function -- see `destroy_via_field`
+   above for the destructor side. Mirrors `test/malloc/malloc.c`'s
+   `mk_point`/`test/dpe/DPE.c`'s `init_engine_context`. `it` is heap-allocated
+   (`malloc`) so `free` (inside `destroy_impl`) is valid; `malloc` gives
+   genuinely uninitialized memory, so an explicit `$unfold-uninit` is needed
+   before the field writes (unlike `vec_fam.c`'s `calloc`-based `vec_new`,
+   whose zeroed memory needs no such unfold). */
+itemx_ptr mk_itemx(void)
 {
     struct itemx *it = (struct itemx *) malloc(sizeof(struct itemx));
     _ghost_stmt($unfold-uninit(struct itemx) $(it));
     it->destroy = destroy_impl;
     it->n = 0;
     _ghost_stmt(Pulse.Lib.C.FuncPtr.of_fn_div_valid _ _ Funcptr_destroy_impl.func_destroy_impl__fp);
+    return it;
+}
+
+void use_mk_itemx(void)
+{
+    itemx_ptr it = mk_itemx();
     destroy_via_field(it);
 }
 

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -474,6 +474,7 @@ int32_t use_hof(void)
 _include_pulse(Apply_weaker_spec,
   unfold
   let aw_post (x_fp: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
+              (y_fp: erased unit)
               (return_1: Typedef_int32_t.ty_int32_t) : slprop =
     let var_a = fst x_fp in
     let var_b = snd x_fp in
@@ -488,15 +489,17 @@ _include_pulse(Apply_weaker_spec,
 
   ghost
   fn wpost_weak (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-                (y: Typedef_int32_t.ty_int32_t)
-    requires (Pulse.Lib.C.FuncPtr.post_of Funcptr_subtract.func_subtract__fp) x y
-    ensures aw_post x y
+                (y: erased unit)
+                (r: Typedef_int32_t.ty_int32_t)
+    requires (Pulse.Lib.C.FuncPtr.post_of Funcptr_subtract.func_subtract__fp) x y r
+    ensures aw_post x y r
   { () }
 
   ghost
   fn wpre_id (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-    requires (Pulse.Lib.C.FuncPtr.pre_of Funcptr_subtract.func_subtract__fp) x
-    ensures (Pulse.Lib.C.FuncPtr.pre_of Funcptr_subtract.func_subtract__fp) x
+             (y: erased unit)
+    requires (Pulse.Lib.C.FuncPtr.pre_of Funcptr_subtract.func_subtract__fp) x y
+    ensures (Pulse.Lib.C.FuncPtr.pre_of Funcptr_subtract.func_subtract__fp) x y
   { () }
 
   ghost
@@ -582,7 +585,8 @@ int32_t is_set(int32_t (*fp)(int32_t, int32_t) _nullable)
 _include_pulse(Reassign_join_spec,
   unfold
   let rj_pre (g: bool)
-             (x_fp: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t)) : slprop =
+             (x_fp: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
+             (y_fp: erased unit) : slprop =
     let var_a = (fst x_fp) in
     let var_b = (snd x_fp) in
     ((Typedef_int32_t.ty_int32_t__pred var_a 1.0R)) **
@@ -602,6 +606,7 @@ _include_pulse(Reassign_join_spec,
   unfold
   let rj_post (g: bool)
               (x_fp: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
+              (y_fp: erased unit)
               (return_1: Typedef_int32_t.ty_int32_t) : slprop =
     let var_a = (fst x_fp) in
     let var_b = (snd x_fp) in
@@ -622,28 +627,32 @@ _include_pulse(Reassign_join_spec,
 
   ghost
   fn wpre_sub (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-    requires rj_pre true x
-    ensures (Pulse.Lib.C.FuncPtr.pre_of Funcptr_subtract.func_subtract__fp) x
+              (y: erased unit)
+    requires rj_pre true x y
+    ensures (Pulse.Lib.C.FuncPtr.pre_of Funcptr_subtract.func_subtract__fp) x y
   { () }
 
   ghost
   fn wpost_sub (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-               (y: Typedef_int32_t.ty_int32_t)
-    requires (Pulse.Lib.C.FuncPtr.post_of Funcptr_subtract.func_subtract__fp) x y
-    ensures rj_post true x y
+               (y: erased unit)
+               (r: Typedef_int32_t.ty_int32_t)
+    requires (Pulse.Lib.C.FuncPtr.post_of Funcptr_subtract.func_subtract__fp) x y r
+    ensures rj_post true x y r
   { () }
 
   ghost
   fn wpre_add (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-    requires rj_pre false x
-    ensures (Pulse.Lib.C.FuncPtr.pre_of Funcptr_add.func_add__fp) x
+              (y: erased unit)
+    requires rj_pre false x y
+    ensures (Pulse.Lib.C.FuncPtr.pre_of Funcptr_add.func_add__fp) x y
   { () }
 
   ghost
   fn wpost_add (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-               (y: Typedef_int32_t.ty_int32_t)
-    requires (Pulse.Lib.C.FuncPtr.post_of Funcptr_add.func_add__fp) x y
-    ensures rj_post false x y
+               (y: erased unit)
+               (r: Typedef_int32_t.ty_int32_t)
+    requires (Pulse.Lib.C.FuncPtr.post_of Funcptr_add.func_add__fp) x y r
+    ensures rj_post false x y r
   { () }
 
 )
@@ -994,15 +1003,17 @@ int32_t apply_t(int32_t (*op)(int32_t, int32_t)
 _include_pulse(Total_to_div_spec,
   ghost
   fn wpre_id (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-    requires (Pulse.Lib.C.FuncPtr.pre_of_tot Funcptr_add_t.func_add_t__fp) x
-    ensures (Pulse.Lib.C.FuncPtr.pre_of_tot Funcptr_add_t.func_add_t__fp) x
+             (y: erased unit)
+    requires (Pulse.Lib.C.FuncPtr.pre_of_tot Funcptr_add_t.func_add_t__fp) x y
+    ensures (Pulse.Lib.C.FuncPtr.pre_of_tot Funcptr_add_t.func_add_t__fp) x y
   { () }
 
   ghost
   fn wpost_id (x: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
-               (y: Typedef_int32_t.ty_int32_t)
-    requires (Pulse.Lib.C.FuncPtr.post_of_tot Funcptr_add_t.func_add_t__fp) x y
-    ensures (Pulse.Lib.C.FuncPtr.post_of_tot Funcptr_add_t.func_add_t__fp) x y
+               (y: erased unit)
+               (r: Typedef_int32_t.ty_int32_t)
+    requires (Pulse.Lib.C.FuncPtr.post_of_tot Funcptr_add_t.func_add_t__fp) x y r
+    ensures (Pulse.Lib.C.FuncPtr.post_of_tot Funcptr_add_t.func_add_t__fp) x y r
   { () }
 
   ghost
@@ -1032,6 +1043,88 @@ int32_t weaken_total_to_div(void)
     return apply_t(add_t, 2, 3);
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
+
+/* Plain pointer parameter, no workaround annotations: PAL's auto-generated
+   ownership for `int *p` is `exists* v. pts_to p v`. Taking `touch`'s
+   address forces a `__fp` wrapper whose contract must be recovered via
+   `pre_of`/`post_of` type-reflection. This now VERIFIES: `pre`/`post`
+   (`Pulse.Lib.C.FuncPtr.fsti`) take an extra explicit `erased c` witness
+   parameter after the wrapper's own argument, so the wrapper's real type is
+   the flat `x:a -> y:erased c -> stt_div b (pre x y) (post x y)`
+   `pre_of`/`post_of` need -- the pointee's ownership is threaded through `y`
+   instead of a hidden implicit binder Pulse would otherwise introduce by
+   opening a top-level `exists*` (which is what broke HOU with Error 189). */
+void touch(int *p)
+{
+}
+
+void use_touch_fp(void)
+{
+    void (*cb)(int *) = touch;
+}
+
+/* Also now verifies, for the same reason as `touch` above (not a strict-
+   positivity error): `struct itemx` itself is fine here -- `destroy`'s field
+   type stays a plain, non-recursive `func_ptr (ref struct_itemx) unit`, no
+   self-reference, no Error 3. `destroy_impl`'s plain pointer parameter gets
+   PAL's usual auto-derived `exists* v. pts_to self v` ownership, and
+   `Itemx_spec.itemx_valid` recovers `pre_of`/`post_of
+   Funcptr_destroy_impl.func_destroy_impl__fp` via the same explicit-witness
+   mechanism. */
+struct itemx {
+    void (*destroy)(struct itemx *self);
+    unsigned int n;
+};
+
+void destroy_impl(struct itemx *self)
+{
+}
+
+void use_destroy_impl_fp(void)
+{
+    void (*cb)(struct itemx *) = destroy_impl;
+}
+
+_include_pulse(Itemx_spec,
+  unfold let itemx_valid ([@@@mkey] this: ref Struct_itemx.struct_itemx) (vo: Struct_itemx.struct_itemx) : slprop =
+    Pulse.Lib.Reference.pts_to this vo **
+    Pulse.Lib.C.FuncPtr.is_valid vo.Struct_itemx.struct_itemx__destroy true (Pulse.Lib.C.FuncPtr.pre_of Funcptr_destroy_impl.func_destroy_impl__fp) (Pulse.Lib.C.FuncPtr.post_of Funcptr_destroy_impl.func_destroy_impl__fp)
+)
+
+_type(itemx_val, Struct_itemx.struct_itemx)
+_refine_value(itemx_val vo, _inline_pulse(Itemx_spec.itemx_valid $(this) $(vo)))
+_plain
+typedef struct itemx *itemx_ptr;
+
+/* [not yet verified -- separate, harder limitation from the one above]
+   Self-dispatch through a field: `p->destroy(p)` both (a) reads the callee
+   off `p` via the struct's usual field-getter (`struct_itemx__get_destroy`,
+   which implicitly unfolds `p`'s `pts_to` to split out the field) and (b)
+   needs `p`'s pointee as the explicit witness value for `destroy_impl`'s
+   `self` parameter. Each of these opens its OWN existential name for "the
+   struct value at `p`" independently, and Pulse cannot automatically prove
+   the two are the same value -- even when read back-to-back with no
+   intervening mutation (confirmed by direct experimentation: naming one
+   shared read explicitly still produces two distinct bound names). Fixing
+   this needs either a `with`-based Pulse idiom threaded through PAL's
+   fnptr-call emission, or a change to the struct field-getter to reuse an
+   already-open existential -- left as follow-up work. */
+#if 0
+void destroy_via_field(itemx_ptr p) {
+    p->destroy(p);
+}
+
+void use_destroy_via_field(void)
+{
+    struct itemx it;
+    _ghost_stmt($unfold-uninit(struct itemx) $&(it));
+    it.destroy = destroy_impl;
+    it.n = 0;
+    _ghost_stmt(Pulse.Lib.C.FuncPtr.of_fn_div_valid _ _ Funcptr_destroy_impl.func_destroy_impl__fp);
+    destroy_via_field(&it);
+    _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
+}
+#endif
 
 #if 0
 

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -2,31 +2,18 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/* ==========================================================================
- * Function-pointer tests against the axiomatized Pulse.Lib.C.FuncPtr library.
- * Every example here verifies (`make -C test/func_pointer`); the single deferred
- * case (`rec_via_ptr`) is kept under `#if 0` at the end.
+/* Function-pointer tests against the axiomatized Pulse.Lib.C.FuncPtr library.
+ * All examples verify except `rec_via_ptr` (`#if 0` at the end).
  *
- * Divergence: PAL emits every function as `divergent fn` (`stt_div`) unless it
- * carries `_total`. FuncPtr validity therefore tracks a `div: bool` bit. A
- * pointer to a divergent target (the common case) is reflected with `of_fn_div`
- * and seeded with `of_fn_div_valid` (baking `div = true`); a `_total` target
- * (e.g. `add_t`) uses `of_fn`/`of_fn_valid` (`div = false`). An indirect call
- * emits `call` from a `_total` body and `call_div` from a divergent one, so the
- * required validity bit matches the enclosing body. A total pointer can be used
- * where a divergent one is expected by `weaken`-ing `false` up to `true`
- * (`weaken_total_to_div`); the reverse is unsound and forbidden.
+ * Divergence: every function is `divergent fn` unless `_total`. A pointer to
+ * a divergent target uses `of_fn_div`/`of_fn_div_valid`; a `_total` target
+ * uses `of_fn`/`of_fn_valid`. Calls use `call_div`/`call` to match. A total
+ * pointer can `weaken` up to divergent, never the reverse.
  *
- * Indirect-call recipe: a call `fp(x)` emits `call{,_div} _ _ (!fp) args` with
- * the spec left as inference holes. For a pointer holding a concrete `of_fn{,_div}
- * ..` (a decayed named function), seed the validity fact just before the call
- * with `_ghost_stmt(.. of_fn_div_valid ..)` (or `of_fn_valid` for a `_total`
- * target). `call{,_div}` returns `is_valid` in its postcondition (validity is a
- * persistent pure fact), so a caller that does not itself export validity drops
- * the surplus afterwards with `_ghost_stmt(.. drop_is_valid _ _ _)`. Callback
- * parameters instead export `is_valid` via a `_refine` refinement (with the
- * matching `div` bit) and keep the returned fact.
- * ========================================================================== */
+ * Indirect-call recipe: seed validity with `_ghost_stmt(.. of_fn_div_valid ..)`
+ * before calling `fp(x)`; drop the returned `is_valid` fact afterwards with
+ * `_ghost_stmt(.. drop_is_valid _ _ _)` unless it needs to be kept. Callback
+ * parameters instead get `is_valid` via a `_refine` on the parameter. */
 
 /* ---- shared helper callees ---- */
 
@@ -37,10 +24,8 @@ int32_t add(int32_t a, int32_t b)
     return a + b;
 }
 
-/* A `_total` (non-divergent) twin of `add`. Its `__fp` wrapper is emitted as a
-   plain `fn` and reflected with `of_fn`, so `of_fn_valid` seeds validity at the
-   total bit `false`. Used to test total function pointers and total->divergent
-   weakening. */
+/* A `_total` (non-divergent) twin of `add`, for testing total function
+   pointers and total->divergent weakening. */
 _total
 int32_t add_t(int32_t a, int32_t b)
     _requires(a > 0 && a < 100 && b > 0 && b < 100)
@@ -221,11 +206,8 @@ int32_t use_null_truthiness(void)
     return 0;
 }
 
-/* Null comparison in a *spec* (not just a body). `f != 0` and `f != NULL` both
-   lower to `FuncPtr.is_null`, so the postcondition follows from the
-   precondition even though the two spellings differ. The body returns the
-   comparison itself, which exercises the same lowering in value position; here
-   `f == NULL` is false, so the result is 0. */
+/* Null comparison in a spec: `f != 0` and `f != NULL` both lower to
+   `is_null`, so the ensures holds regardless of spelling. */
 int32_t fp_spec_nonnull(binop f)
     _requires(f != 0)
     _ensures(f != NULL && return == 0)
@@ -352,9 +334,7 @@ int32_t loop_call(void)
 }
 
 /* ---- callback parameters (abstract func_ptr params) ----
-   The pointer is a func_ptr PARAMETER, so the caller supplies the `is_valid`
-   fact via a `_refine((_slprop) is_valid $(this) ..)` refinement on the
-   parameter, landing it in both the generated `requires` and `ensures`. */
+   A `_refine` on the parameter supplies the `is_valid` fact for the call. */
 
 /* Function pointer as a callback parameter. */
 int32_t apply(int32_t (*op)(int32_t, int32_t)
@@ -440,10 +420,9 @@ int32_t use_forward(void)
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
 
-/* Higher-order: the callback `g` is itself a function that takes a function
-   pointer (like `apply`). After `g(add, ..)` returns, two `is_valid` facts are
-   live -- `g`'s own (exported here) and `add`'s (returned by `apply`'s ensures)
-   -- so the surplus `add` fact is dropped by pinning its `f`. */
+/* Higher-order: `g` itself takes a function pointer (like `apply`). Two
+   `is_valid` facts are live after `g(add, ..)` -- `g`'s own and `add`'s --
+   so the surplus `add` fact is dropped. */
 int32_t hof(int32_t (*g)(int32_t (*)(int32_t, int32_t), int32_t, int32_t)
                 _refine((_slprop) _inline_pulse(
                     Pulse.Lib.C.FuncPtr.is_valid $(this) true
@@ -467,10 +446,9 @@ int32_t use_hof(void)
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
 
-/* `apply_weaker` takes a callback whose declared post (`aw_post`) is WEAKER than
-   `subtract` provides. `weaken_sub_to_aw` moves subtract's validity onto the
-   weaker spec (identity pre-coercion; post-coercion proving
-   `return == a - b ==> return < a` under the shared precondition). */
+/* `apply_weaker` takes a callback whose declared post (`aw_post`) is weaker
+   than `subtract` provides; `weaken_sub_to_aw` moves subtract's validity
+   onto that weaker spec. */
 _include_pulse(Apply_weaker_spec,
   unfold
   let aw_post (x_fp: (Typedef_int32_t.ty_int32_t & Typedef_int32_t.ty_int32_t))
@@ -558,12 +536,9 @@ int32_t guarded_call(int32_t (*fp)(int32_t, int32_t) _nullable
     return 0;
 }
 
-/* Bare `_nullable` callback, i.e. no `_refine`. Without a refinement there is no
-   `is_valid` to carry, so the parameter's slprop is the empty `unless_null fp emp`
-   -- the same shape a `_nullable` data pointer with a prop-less pointee gets. The
-   pointer can still be null-tested; it just cannot be called, since nothing
-   establishes its validity. This exercises the plain `unless_null` path for
-   function pointers, which relies on the `has_is_null_func_ptr` instance. */
+/* Bare `_nullable` callback, no `_refine`: no `is_valid` to carry, so the
+   parameter's slprop is just `unless_null fp emp`. Can be null-tested but
+   not called. Exercises `has_is_null_func_ptr`. */
 int32_t is_set(int32_t (*fp)(int32_t, int32_t) _nullable)
     _ensures(return == 0 || return == 1)
 {
@@ -574,11 +549,10 @@ int32_t is_set(int32_t (*fp)(int32_t, int32_t) _nullable)
 }
 
 /* ---- join family ----
-   The pointer is bound to different functions across a control-flow join and
-   called after the merge, so no single static target exists at the call site.
-   Each branch weakens its per-branch validity onto a common guard-keyed spec
-   `(rj_pre g)(rj_post g)`; an `_ensures` on the `if` carries the join existential
-   `exists* v. pts_to fp v ** is_valid v (rj_pre g)(rj_post g)`. */
+   The pointer is bound to different functions across a control-flow join,
+   so no single static target exists at the call site. Each branch weakens
+   its validity onto a common guard-keyed spec `(rj_pre g)(rj_post g)`,
+   carried across the join by an `_ensures` on the `if`. */
 
 /* Guard-keyed pre/post (`rj_pre`/`rj_post`) and the per-branch weakenings used
    by the join-family examples below. */
@@ -796,15 +770,9 @@ void inc(int32_t *p)
 
 /* ---- DISABLED: relational `_old` on an ownership pointer through an
    indirect (function-pointer) call ----
-   `ptr_arg_cb` passes an ownership pointer through a FuncPtr to a callee
-   (`inc`) whose contract is relational (`*p == _old(*p) + 1`). The pointer
-   still gets its default `pts_to` permission across the FuncPtr, but the
-   FuncPtr contract (`pre: a -> slprop`, `post: a -> b -> slprop`) is
-   non-relational: expressing `_old(*p)` would need the pointer's initial
-   pointee value threaded through the FuncPtr domain, which has been removed
-   (fnptr arguments are now always plain values). So `_old(*p)` across an
-   indirect call is unsupported. Disabled until first-class `_old` support in
-   FuncPtr contracts is reinstated.
+   `_old(*p)` needs the pointer's initial value threaded through the FuncPtr
+   domain, which no longer exists (fnptr arguments are plain values only).
+   Disabled until FuncPtr contracts support `_old` again.
 
 void ptr_arg_cb(int32_t *p)
     _requires(*p < 100)
@@ -818,25 +786,13 @@ void ptr_arg_cb(int32_t *p)
 ---- end DISABLED ptr_arg_cb ---- */
 
 /* ---- DISABLED: storing a function pointer into an array element ----
-   The four functions below (assign_from_agg, use_array_slot, array_runtime_idx,
-   multilayer) each write a function pointer into an array slot (`tbl[i] = add;`).
-
-   PAL used to work around a verification failure here with an ad-hoc trick: it
-   let-bound the stored value to a temporary before `array_write`, so the array
-   spec update stayed over a small variable. That trick has been removed, so the
-   value (a large `of_fn_div (pre_of __fp) (post_of __fp) __fp` term) is now
-   inlined directly into `array_write`. This makes
-   `array_spec_upd s i (of_fn ...)` too large for the `array_spec_upd_*` SMTPats
-   to fire, so the subsequent read-back cannot prove `array_spec_mask` /
-   `array_spec_initd` nor recover the stored pointer.
-
-   Increasing `z3rlimit` does NOT help: this was verified empirically (the proof
-   fails identically at `--z3rlimit 50` and `--z3rlimit 300`, with the same
-   `VC = array_spec_mask _s' 1`). The problem is SMTPat trigger/congruence
-   matching against an over-large term, not a Z3 resource-budget problem.
-
-   These are disabled until a proper library-level fix (making `array_write`'s
-   spec robust to large stored values) is implemented.
+   These four functions each write a function pointer into an array slot
+   (`tbl[i] = add;`). Storing the large `of_fn_div ...` term directly makes
+   `array_spec_upd s i (of_fn ...)` too large for the `array_spec_upd_*`
+   SMTPats to fire, so the read-back can't recover `array_spec_mask`/
+   `array_spec_initd`. This is an SMTPat matching issue, not a Z3 resource
+   problem (confirmed: raising `z3rlimit` doesn't help). Disabled until
+   `array_write`'s spec is made robust to large stored values.
 
 int32_t assign_from_agg(void)
     _ensures(return == 5)
@@ -970,11 +926,9 @@ int32_t use_two_field_vtable(void)
 
 /* ---- total function pointers & total->divergent weakening ---- */
 
-/* A `_total` caller holding a pointer to the `_total` `add_t`. Because `add_t`
-   is total, its wrapper is reflected with `of_fn` and `of_fn_valid` seeds
-   `is_valid .. false ..`; because the caller body is itself `_total`, the
-   indirect call emits `call` (the total primitive returning `stt`). Shows that
-   total function pointers verify end-to-end. */
+/* A `_total` caller holding a pointer to the `_total` `add_t`: `of_fn_valid`
+   seeds `is_valid .. false ..`, and the indirect call emits `call` (the
+   total primitive). Total function pointers verify end-to-end. */
 _total
 int32_t use_total_fp(void)
     _ensures(return == 5)
@@ -1045,11 +999,9 @@ int32_t weaken_total_to_div(void)
 }
 
 /* Plain pointer parameter, no workaround annotations. Taking `touch`'s
-   address forces a `__fp` wrapper recovered via `pre_of`/`post_of`
-   type-reflection. Now VERIFIES: `pre_of`/`post_of` take an explicit
-   `erased c` witness parameter, so the wrapper's ownership is threaded
-   through it instead of a hidden implicit binder (which broke HOU with
-   Error 189). */
+   address forces a `__fp` wrapper via `pre_of`/`post_of` type-reflection;
+   verifies because those take an explicit `erased c` witness parameter
+   instead of a hidden implicit binder (which broke HOU with Error 189). */
 void touch(int *p)
 {
 }
@@ -1079,6 +1031,11 @@ void use_destroy_impl_fp(void)
     void (*cb)(struct itemx *) = destroy_impl;
 }
 
+/* `Itemx_spec` is a separate module (not a field-level `_refine` on
+   `destroy`) because `destroy_impl`'s spec module already depends on
+   `struct itemx`; folding `is_valid` into the struct's own predicate would
+   make `Struct_itemx` depend back on it, a circular module dependency
+   (Error 308). */
 _include_pulse(Itemx_spec,
   unfold let itemx_valid ([@@@mkey] this: ref Struct_itemx.struct_itemx) (vo: Struct_itemx.struct_itemx) : slprop =
     Pulse.Lib.Reference.pts_to this vo **
@@ -1091,27 +1048,22 @@ _refine_value(itemx_val vo, _inline_pulse(Itemx_spec.itemx_valid $(this) $(vo)))
 _plain
 typedef struct itemx *itemx_ptr;
 
-/* Self-dispatch through a field VERIFIES once `self` is `_consumes`. With a
-   borrowed `self`, the call-site witness read (`!(!p)`) and the field
-   getter's own unfold of `p->destroy` each opened a separate existential
-   for the same value, which Pulse couldn't unify (Error 228). Consuming `p`
-   binds ONE top-level existential that both projections read from, so
-   there's no second name to clash with. `itemx_valid` also asserts
-   `freeable this`, giving `destroy_impl` the fact it needs to `free`.
+/* Self-dispatch through a field verifies once `self` is `_consumes`: a
+   borrowed `self` opens two separate existentials for the same value
+   (call-site witness vs. field-getter unfold), which Pulse can't unify
+   (Error 228). Consuming `p` binds ONE existential both read from.
+   `itemx_valid` also asserts `freeable`, for `destroy_impl`'s `free`.
    `drop_is_valid` clears the leftover non-affine `is_valid` fact. */
 void destroy_via_field(_consumes itemx_ptr p) {
     p->destroy(p);
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
 
-/* Constructs a valid `struct itemx` and RETURNS it (as `itemx_ptr`), instead
-   of consuming it immediately in the same function -- see `destroy_via_field`
-   above for the destructor side. Mirrors `test/malloc/malloc.c`'s
-   `mk_point`/`test/dpe/DPE.c`'s `init_engine_context`. `it` is heap-allocated
-   (`malloc`) so `free` (inside `destroy_impl`) is valid; `malloc` gives
-   genuinely uninitialized memory, so an explicit `$unfold-uninit` is needed
-   before the field writes (unlike `vec_fam.c`'s `calloc`-based `vec_new`,
-   whose zeroed memory needs no such unfold). */
+/* Constructs a valid `struct itemx` and RETURNS it, instead of consuming it
+   immediately (see `destroy_via_field`). Mirrors `test/malloc/malloc.c`'s
+   `mk_point`. `malloc`'s memory is genuinely uninitialized, so an explicit
+   `$unfold-uninit` is needed before the field writes (unlike `vec_fam.c`'s
+   `calloc`-based `vec_new`). */
 itemx_ptr mk_itemx(void)
 {
     struct itemx *it = (struct itemx *) malloc(sizeof(struct itemx));
@@ -1130,13 +1082,12 @@ void use_mk_itemx(void)
 
 #if 0
 
-/* [not yet verified -- DEFERRED, emitter mutual-recursion gap] Indirect
-   recursion through a function pointer. Taking the address of the function under
-   definition decays to `of_fn .. func_rec_via_ptr__fp`, but PAL emits the
-   function and its lifted triple as two SEPARATE top-level `fn`s (not a
-   `fn rec .. and ..` group), so the reference is forward (F* Error 72). The fix
-   is an emitter change to emit the recursive function and its address-taken
-   `__fp` triple as a single mutually-recursive group. */
+/* [DEFERRED] Indirect recursion through a function pointer. Taking the
+   address of the function under definition decays to `of_fn ..
+   func_rec_via_ptr__fp`, but PAL emits the function and its lifted triple
+   as two separate top-level `fn`s (not a `fn rec .. and ..` group), so the
+   reference is forward (F* Error 72). Needs an emitter change to emit both
+   as one mutually-recursive group. */
 _rec int32_t rec_via_ptr(int32_t n)
     _requires(n >= 0 && n < 100)
     _ensures(return == 0)

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -1063,21 +1063,21 @@ void use_touch_fp(void)
     void (*cb)(int *) = touch;
 }
 
-/* Also now verifies, for the same reason as `touch` above (not a strict-
-   positivity error): `struct itemx` itself is fine here -- `destroy`'s field
-   type stays a plain, non-recursive `func_ptr (ref struct_itemx) unit`, no
-   self-reference, no Error 3. `destroy_impl`'s plain pointer parameter gets
-   PAL's usual auto-derived `exists* v. pts_to self v` ownership, and
-   `Itemx_spec.itemx_valid` recovers `pre_of`/`post_of
-   Funcptr_destroy_impl.func_destroy_impl__fp` via the same explicit-witness
-   mechanism. */
+/* `struct itemx` itself verifies fine here -- `destroy`'s field type stays a
+   plain, non-recursive `func_ptr (ref struct_itemx) unit`, no self-
+   reference, no strict-positivity Error 3. */
 struct itemx {
     void (*destroy)(struct itemx *self);
     unsigned int n;
 };
 
-void destroy_impl(struct itemx *self)
+/* Now VERIFIES. `destroy_impl`'s `self` is `_consumes _allocated`: a real
+   destructor that takes ownership of its receiver and frees it, rather than
+   merely borrowing it (same annotation combo as `test/dpe/DPE.c`'s
+   `destroy_uds_context`). */
+void destroy_impl(_consumes _allocated struct itemx *self)
 {
+    free(self);
 }
 
 void use_destroy_impl_fp(void)
@@ -1088,6 +1088,7 @@ void use_destroy_impl_fp(void)
 _include_pulse(Itemx_spec,
   unfold let itemx_valid ([@@@mkey] this: ref Struct_itemx.struct_itemx) (vo: Struct_itemx.struct_itemx) : slprop =
     Pulse.Lib.Reference.pts_to this vo **
+    Pulse.Lib.C.Ref.freeable this **
     Pulse.Lib.C.FuncPtr.is_valid vo.Struct_itemx.struct_itemx__destroy true (Pulse.Lib.C.FuncPtr.pre_of Funcptr_destroy_impl.func_destroy_impl__fp) (Pulse.Lib.C.FuncPtr.post_of Funcptr_destroy_impl.func_destroy_impl__fp)
 )
 
@@ -1096,35 +1097,48 @@ _refine_value(itemx_val vo, _inline_pulse(Itemx_spec.itemx_valid $(this) $(vo)))
 _plain
 typedef struct itemx *itemx_ptr;
 
-/* [not yet verified -- separate, harder limitation from the one above]
-   Self-dispatch through a field: `p->destroy(p)` both (a) reads the callee
-   off `p` via the struct's usual field-getter (`struct_itemx__get_destroy`,
-   which implicitly unfolds `p`'s `pts_to` to split out the field) and (b)
-   needs `p`'s pointee as the explicit witness value for `destroy_impl`'s
-   `self` parameter. Each of these opens its OWN existential name for "the
-   struct value at `p`" independently, and Pulse cannot automatically prove
-   the two are the same value -- even when read back-to-back with no
-   intervening mutation (confirmed by direct experimentation: naming one
-   shared read explicitly still produces two distinct bound names). Fixing
-   this needs either a `with`-based Pulse idiom threaded through PAL's
-   fnptr-call emission, or a change to the struct field-getter to reuse an
-   already-open existential -- left as follow-up work. */
-#if 0
-void destroy_via_field(itemx_ptr p) {
+/* Self-dispatch through a field now VERIFIES too, once `self` is
+   `_consumes`, resolving the earlier "two independent existentials for the
+   same value" mismatch (Error 228: `is_valid val_p_0... ` vs
+   `is_valid _val_self_0XX...`) documented as a known limitation before this
+   change. With a plain (borrowed, non-consuming) `self`, the call site's
+   witness computation (`hide (!(!p))`, needed to instantiate `destroy_impl`'s
+   `erased c` parameter) and the field-getter's own unfold of `p->destroy`
+   each independently opened the struct's `pts_to` existential, producing
+   two different bound names for what is semantically the same value, which
+   Pulse could not unify. With `_consumes itemx_ptr p`, `p`'s OWN top-level
+   existential (`val_p_0`, bound once by `destroy_via_field`'s `requires`)
+   is the SAME name both the field-getter and the witness computation read
+   from -- there is no second, independently-opened existential to clash
+   with, since consuming `p` up front (rather than borrowing through a
+   pointer indirection) means both projections happen against one and the
+   same already-opened value. The `itemx_valid` predicate now also asserts
+   `freeable this`, so consuming `p` yields both the `is_valid` fact needed
+   to dispatch through the field and the `freeable` fact `destroy_impl`
+   needs to physically `free` the struct. An explicit `drop_is_valid` is
+   needed at the end since `is_valid` is a non-affine fact left over after
+   the call. */
+void destroy_via_field(_consumes itemx_ptr p) {
     p->destroy(p);
-}
-
-void use_destroy_via_field(void)
-{
-    struct itemx it;
-    _ghost_stmt($unfold-uninit(struct itemx) $&(it));
-    it.destroy = destroy_impl;
-    it.n = 0;
-    _ghost_stmt(Pulse.Lib.C.FuncPtr.of_fn_div_valid _ _ Funcptr_destroy_impl.func_destroy_impl__fp);
-    destroy_via_field(&it);
     _ghost_stmt(Pulse.Lib.C.FuncPtr.drop_is_valid _ _ _);
 }
-#endif
+
+/* `it` must be heap-allocated (`malloc`, not the stack) so `free` inside
+   `destroy_impl` is valid. Like the earlier stack-allocated version, a
+   freshly-`malloc`'d struct pointer still needs an explicit
+   `$unfold-uninit` to expose its per-field uninitialized cells before the
+   individual field writes below -- `malloc` gives genuinely uninitialized
+   memory (unlike `test/vec_fam/vec_fam.c`'s `calloc`-based `vec_new`, whose
+   zeroed memory can be treated as already-initialized field values). */
+void use_destroy_via_field(void)
+{
+    struct itemx *it = (struct itemx *) malloc(sizeof(struct itemx));
+    _ghost_stmt($unfold-uninit(struct itemx) $(it));
+    it->destroy = destroy_impl;
+    it->n = 0;
+    _ghost_stmt(Pulse.Lib.C.FuncPtr.of_fn_div_valid _ _ Funcptr_destroy_impl.func_destroy_impl__fp);
+    destroy_via_field(it);
+}
 
 #if 0
 


### PR DESCRIPTION
### TLDR
At the moment, function pointers dont work for functions with pointers as arguments. This is because Pulse eliminates the exists quantifier in the precondition of those functions so the postcondition can refer to it. We add an extra erased argument for function pointers to track all those extra erased arguments arising from that elimination.

Also included interesting test cases utilizing function pointers that takes in pointers.

### Problem
Function pointers with plain, unannotated pointer parameters failed to verify with F* Error 189. Pulse elaborates a top-level `exists* v. P v` in a `requires` clause by opening it into a **hidden implicit binder** placed after the function's explicit parameter. This breaks the higher-order unification (HOU) that `pre_of`/`post_of` rely on when reflecting a concrete function as a `func_ptr` value (`x:a -> stt_div b (pre x) (post x)` no longer matches the wrapper's actual shape).

### Fix
Thread an **explicit `erased c` witness parameter** through `Pulse.Lib.C.FuncPtr.fsti`'s combinators (`valid`, `pre_of`, `post_of`, `of_fn`, `of_fn_div`, `call`, `call_div`, `weaken`), and update PAL's emitter (`src/pass/emit.rs`) to:
- detect bare-pointer function-pointer parameters,
- combine any witnessed values into a single `erased` tuple,
- add the explicit witness parameter to generated `__fp` wrappers,
- compute and pass the witness value at call sites.

This makes ownership explicit instead of hidden, restoring the HOU shape `of_fn_div` needs.

### Self-dispatch through a struct field (`p->destroy(p)`)
Extended the fix to a harder case: dispatch through a function-pointer *struct field* on a receiver (`self`/`p`). With a **borrowed** `self`, the call-site witness computation and the field-getter's own unfold each open independent existentials for the same value, which Pulse can't unify (Error 228). Making the receiver `_consumes` collapses this to a single top-level existential both projections read from, resolving the mismatch. Demonstrated end-to-end with `destroy_impl`/`destroy_via_field` in `test/func_pointer/func_pointer.c`, including a real heap `free` via `_consumes _allocated`.

### New test: construct-and-return
Added `mk_itemx()`/`use_mk_itemx()`, constructing a valid `struct itemx` on the heap and returning it (rather than consuming it in the same function), then destroying it via `destroy_via_field`. Verifies with no extra annotations needed beyond the existing `Itemx_spec` design.