### PR TITLE
Avoid materializing opaque string literals

### DIFF
--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -27,7 +27,7 @@ let array_spec_initd #a (s: array_spec a) (i: nat) : prop = i < Seq.length s /\ 
 let array_spec_mask #a (s: array_spec a) (i: nat) : prop = i < Seq.length s /\ ~(OutOfMask? (Seq.index s i))
 let array_spec_idx #a (s: array_spec a) (i: nat { array_spec_initd s i }) : Tot a = let Val x = Seq.index s i in x
 
-let array_literal_to_ref #a #n (_: full_array_lspec a n) : Tot (R.ref a) =
+let array_literal_to_ref #a : Tot (R.ref a) =
   admit ()
 
 let to_mask #t (s: array_spec t) (i: nat) : prop = array_spec_mask s i

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -42,7 +42,7 @@ let full_array_lspec a (l: nat) = s:full_array_spec a { array_spec_len s == l }
 // C string literals have static storage duration. PAL exposes only their address
 // here; clients still need an explicit model before dereferencing a literal
 // returned through an ownership-free (`_plain`) pointer.
-val array_literal_to_ref #a #n (s: full_array_lspec a n) : Tot (R.ref a)
+val array_literal_to_ref #a : Tot (R.ref a)
 
 val array_spec_ext #a (s1 s2: array_spec a) :
   Lemma (requires

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -2866,7 +2866,7 @@ impl<'a> Emitter<'a> {
                             TypeT::FixedArray(_, _),
                             TypeT::Pointer(_, PointerKind::Ref | PointerKind::Unknown),
                         ) => {
-                            let fn_name = if matches!(
+                            if matches!(
                                 &val.val,
                                 ExprT::ArrayInit {
                                     is_static: true,
@@ -2874,12 +2874,12 @@ impl<'a> Emitter<'a> {
                                 }
                             ) {
                                 // String literals have static storage duration,
-                                // unlike local fixed-size arrays.
-                                "Pulse.Lib.C.Array.array_literal_to_ref"
+                                // unlike local fixed-size arrays. The trusted
+                                // model exposes no contents or ownership.
+                                Doc::text("Pulse.Lib.C.Array.array_literal_to_ref")
                             } else {
-                                "Pulse.Lib.C.Array.array_to_ref"
-                            };
-                            unaryfn(Doc::text(fn_name), val_doc)
+                                unaryfn(Doc::text("Pulse.Lib.C.Array.array_to_ref"), val_doc)
+                            }
                         }
                         // `core_ref` (raw `_core_ref` back-pointer) → typed `ref T`:
                         // recover the typed reference. The pointee type is known


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR09 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `main`. Depends on nothing; reviewable on its own.

The trusted static-literal model exposes only a borrowed address — no contents, length
or ownership — so the full array specification built at every decay site was unused.
Making the primitive depend only on the inferred element type keeps the abstraction and
stops large string-heavy switches from generating thousands of irrelevant
character-conversion proof obligations.

### Commits

- Avoid materializing opaque string literals

### Testing

No test directory of its own — this is an enabler whose effect shows up in another PR's fixture, a `pulse/` library lemma, or a `tests-todo` reproducer. Verified with a full `make test -j8` (1372 modules, 0 errors) to confirm it regresses nothing.
