### PR TITLE
Array: expose that an initialized cell is owned and in range

### DIFF
--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -38,6 +38,8 @@ let to_seq #t (s: array_spec t) : GTot (Seq.seq (option t)) =
     | Val x -> Some x
     | _ -> None
 
+let array_spec_initd_mask #a (s: array_spec a) (i: nat) = ()
+
 let array_spec_ext #a (s1 s2: array_spec a) :
   Lemma (requires
     array_spec_len s1 == array_spec_len s2

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -44,6 +44,14 @@ let full_array_lspec a (l: nat) = s:full_array_spec a { array_spec_len s == l }
 // returned through an ownership-free (`_plain`) pointer.
 val array_literal_to_ref #a #n (s: full_array_lspec a n) : Tot (R.ref a)
 
+// An initialized cell is necessarily in range and in the mask: initialization
+// is a strictly stronger state than mere ownership. Both projections are
+// abstract, so a client that knows only `array_spec_initd` cannot recover
+// either fact without this.
+val array_spec_initd_mask #a (s: array_spec a) (i: nat) :
+  Lemma (array_spec_initd s i ==> i < array_spec_len s /\ array_spec_mask s i)
+    [SMTPat (array_spec_initd s i)]
+
 val array_spec_ext #a (s1 s2: array_spec a) :
   Lemma (requires
     array_spec_len s1 == array_spec_len s2


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR10 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `main`. Depends on nothing; reviewable on its own.

`array_spec_initd`, `array_spec_mask` and `array_spec_len` are all abstract, so a client
holding `array_spec_initd s i` could not conclude `i < len` or `array_spec_mask s i`,
both of which hold in the implementation. That is the position a caller of
`array_return_cell` is in.

### Commits

- Array: expose that an initialized cell is owned and in range

### Testing

No test directory of its own — this is an enabler whose effect shows up in another PR's fixture, a `pulse/` library lemma, or a `tests-todo` reproducer. Verified with a full `make test -j8` (1372 modules, 0 errors) to confirm it regresses nothing.
