### PR TITLE
Type switch scrutinee bindings by their enumeration type

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -1891,8 +1891,20 @@ public:
 
       // Evaluate scrutinee
       auto scrutRval = trRValue(sw->getCond());
-      auto scrutTy =
-          trQualType(sw->getCond()->getType(), sw->getCond()->getSourceRange());
+      // Clang applies the integral promotions to the switch condition. An
+      // enumeration is modeled by its underlying integer type, so that
+      // promotion translates to the identity and is elided from the rvalue.
+      // Annotating the binding with the promoted type would then leave the
+      // declared type and the translated value syntactically distinct, which
+      // the Pulse dereference tactic rejects. Use the enumeration's own type
+      // so the two agree; other promotions are genuine casts that trRValue
+      // preserves, so their promoted type remains correct.
+      auto *scrutExpr = sw->getCond();
+      auto scrutQualTy = scrutExpr->getType();
+      if (scrutExpr->IgnoreImpCasts()->getType()->isEnumeralType()) {
+        scrutQualTy = scrutExpr->IgnoreImpCasts()->getType();
+      }
+      auto scrutTy = trQualType(scrutQualTy, scrutExpr->getSourceRange());
 
       // Bind the scrutinee once as an immutable value.
       static int switchCounter = 0;


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR19 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `main`. Depends on nothing; reviewable on its own.

Clang promotes a switch condition, and an enumeration modeled by its underlying integer
type makes that promotion the identity, which the rvalue translation elides — but the
scrutinee binding was still annotated with the promoted type, so the declared type and the
bound value were syntactically distinct and Pulse's dereference tactic, which compares
syntactically, rejected the binding. Other promotions are genuine casts and keep their
promoted type.

### Commits

- Type switch scrutinee bindings by their enumeration type

### Testing

No test directory of its own — this is an enabler whose effect shows up in another PR's fixture, a `pulse/` library lemma, or a `tests-todo` reproducer. Verified with a full `make test -j8` (1372 modules, 0 errors) to confirm it regresses nothing.
