### PR TITLE
Lower a fall-through-free switch as a chain of conditionals

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -2080,6 +2080,53 @@ public:
         }
       }
 
+      // A switch with no fall-through is an if/else chain, and saying so is
+      // better than encoding it: the hit and break flags turn every case test
+      // into a compound condition over mutable state, which leaves the prover
+      // unable to reduce a state-dependent join at the *next* test. Nested
+      // if/else tests the scrutinee directly, so each branch condition is the
+      // one the join is phrased in. Reserved for the unannotated case; an
+      // explicit switch postcondition still takes the match form above.
+      if (hasOnlyTerminalBreaks && !cases.empty() && switchEnss.empty() &&
+          defaultGroup) {
+        auto makeChainBody = [&](SwitchGroup &group) {
+          auto bodyStmts = Vec<Rc<ir::Stmt>>::new_();
+          size_t bodySize = group.body.size() - 1;
+          for (size_t i = 0; i < bodySize; i++)
+            trStmt(bodyStmts, group.body[i]);
+          return bodyStmts;
+        };
+
+        auto chain = makeChainBody(*defaultGroup);
+        size_t remaining = cases.size();
+        for (auto it = cases.rbegin(); it != cases.rend(); ++it) {
+          auto *group = *it;
+          auto childLoc = getRange(group->label->getSourceRange());
+          Rc<ir::Expr> cond = mk_rvalue_binop(
+              childLoc.clone(), ir::BinOp::Eq(),
+              mk_lvalue_var(childLoc.clone(), scrutId.clone()),
+              trRValue(group->caseValues.front()->IgnoreParenImpCasts()));
+          for (size_t i = 1; i < group->caseValues.size(); i++) {
+            auto eq = mk_rvalue_binop(
+                childLoc.clone(), ir::BinOp::Eq(),
+                mk_lvalue_var(childLoc.clone(), scrutId.clone()),
+                trRValue(group->caseValues[i]->IgnoreParenImpCasts()));
+            cond = mk_rvalue_binop(childLoc.clone(), ir::BinOp::LogOr(),
+                                   std::move(cond), std::move(eq));
+          }
+          auto ifStmt =
+              mk_if(childLoc.clone(), std::move(cond), makeChainBody(*group),
+                    std::move(chain), Vec<Rc<ir::Expr>>::new_());
+          if (--remaining == 0) {
+            stmts.push(std::move(ifStmt));
+          } else {
+            chain = Vec<Rc<ir::Stmt>>::new_();
+            chain.push(std::move(ifStmt));
+          }
+        }
+        return {};
+      }
+
       // General switches retain explicit hit and break state to model
       // fall-through.
       auto hitName = "__switch_hit_" + std::to_string(switchIndex);

--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -1951,29 +1951,40 @@ public:
       bool seenDefault = false;
       SwitchGroup *currentGroup = nullptr;
       for (auto *child : comp->body()) {
-        if (auto *cs = dyn_cast<CaseStmt>(child)) {
+        if (isa<CaseStmt>(child) || isa<DefaultStmt>(child)) {
           auto childLoc = getRange(child->getSourceRange());
           if (seenDefault) {
-            reportUnsupported(cs->getSourceRange(), childLoc,
+            reportUnsupported(child->getSourceRange(), childLoc,
                               "default must be the last case in switch", "");
             break;
           }
 
           groups.push_back({child, false, {}, {}});
           currentGroup = &groups.back();
-          Stmt *caseBody = child;
-          while (auto *innerCs = dyn_cast<CaseStmt>(caseBody)) {
-            currentGroup->caseValues.push_back(innerCs->getLHS());
-            caseBody = innerCs->getSubStmt();
+          // Consecutive labels nest: clang makes the second the sub-statement
+          // of the first, so `case A: case B: default:` arrives as a chain
+          // rather than as three siblings. Peel the whole chain, in either
+          // order, so a default sharing an arm with explicit cases is that
+          // arm's default rather than a statement in its body.
+          Stmt *labelBody = child;
+          for (;;) {
+            if (auto *innerCs = dyn_cast<CaseStmt>(labelBody)) {
+              currentGroup->caseValues.push_back(innerCs->getLHS());
+              labelBody = innerCs->getSubStmt();
+            } else if (auto *innerDs = dyn_cast<DefaultStmt>(labelBody)) {
+              currentGroup->isDefault = true;
+              seenDefault = true;
+              labelBody = innerDs->getSubStmt();
+            } else {
+              break;
+            }
           }
-          if (caseBody)
-            currentGroup->body.push_back(caseBody);
-        } else if (auto *ds = dyn_cast<DefaultStmt>(child)) {
-          seenDefault = true;
-          groups.push_back({child, true, {}, {}});
-          currentGroup = &groups.back();
-          if (ds->getSubStmt())
-            currentGroup->body.push_back(ds->getSubStmt());
+          // The arm is reached by anything, so its explicit case values add
+          // nothing and would otherwise be emitted as a redundant test.
+          if (currentGroup->isDefault)
+            currentGroup->caseValues.clear();
+          if (labelBody)
+            currentGroup->body.push_back(labelBody);
         } else if (currentGroup) {
           currentGroup->body.push_back(child);
         } else {

--- a/test/switch_stmt/switch_stmt.c
+++ b/test/switch_stmt/switch_stmt.c
@@ -46,6 +46,92 @@ int32_t classify(int32_t x)
     return r;
 }
 
+/* A default sharing an arm with explicit cases. C nests consecutive labels, so
+   `case 2: case 3: default:` reaches the translator as a chain rather than as
+   siblings; the arm is the default one and its explicit values add nothing. */
+int32_t default_after_cases(int32_t x)
+    _ensures(x == 0 ==> return == 10)
+    _ensures(x == 1 ==> return == 20)
+    _ensures((x != 0 && x != 1) ==> return == 30)
+{
+    int32_t r = 0;
+    switch (x) {
+    case 0:
+        r = 10;
+        break;
+    case 1:
+        r = 20;
+        break;
+    case 2:
+    case 3:
+    default:
+        r = 30;
+        break;
+    }
+    return r;
+}
+
+/* The same shape without a terminal break on the default arm, which takes the
+   general fall-through encoding rather than the match one. */
+int32_t default_after_cases_no_break(int32_t x)
+    _ensures(x == 0 ==> return == 10)
+    _ensures((x != 0) ==> return == 30)
+{
+    int32_t r = 0;
+    switch (x) {
+    case 0:
+        r = 10;
+        break;
+    case 2:
+    default:
+        r = 30;
+    }
+    return r;
+}
+
+/* A default written before the cases it shares an arm with. */
+int32_t default_before_cases(int32_t x)
+    _ensures(x == 1 ==> return == 20)
+    _ensures(x != 1 ==> return == 30)
+{
+    int32_t r = 0;
+    switch (x) {
+    case 1:
+        r = 20;
+        break;
+    default:
+    case 2:
+        r = 30;
+        break;
+    }
+    return r;
+}
+
+/* The annotated form of the same shape, which takes the terminal-break match
+   encoding, so the shared default must become the match's wildcard arm. The
+   postcondition is disjunctive because a wildcard arm carries no hypothesis
+   that the earlier patterns did not match, which is so for a lone `default`
+   too and is not particular to a default sharing an arm with cases. */
+int32_t default_after_cases_annotated(int32_t x)
+    _ensures(return == 10 || return == 30)
+{
+    int32_t r = 0;
+    switch (x)
+        _ensures(_live(x) && _live(r))
+        _ensures(r == 10 || r == 30)
+    {
+    case 0:
+        r = 10;
+        break;
+    case 2:
+    case 3:
+    default:
+        r = 30;
+        break;
+    }
+    return r;
+}
+
 /* A genuine fall-through switch retains the general switch encoding. */
 int32_t accumulate_with_fallthrough(int32_t x)
     _requires(x == 0 || x == 1)


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR20 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `main`. Depends on nothing; reviewable on its own.

Consecutive labels *nest* in clang, so `case 2: case 3: default:` arrives as
`CaseStmt(2, CaseStmt(3, DefaultStmt(..)))`; the group builder peeled only the `CaseStmt`
chain and statement translation then rejected the stray `DefaultStmt`. Peels the whole
chain in either order and marks the group default, dropping its explicit case values —
an arm reached by anything gains nothing from also testing for 2 or 3. The second commit
lowers a fall-through-free switch with a `default` as an if/else chain: the general
encoding threads `hit`/`brk` flags, so every arm executes under a compound condition over
mutable state, and the join — phrased in terms of the scrutinee — never meets the guards.
An explicit switch postcondition still takes the match form, which needs one.

### Commits

- Recognize a default that shares an arm with explicit cases
- Lower a fall-through-free switch as a chain of conditionals

### Testing

Verified: `make rust lib`, `test/check-template.sh`, `cargo fmt --check`, `clang-format --dry-run --Werror`, and F* verification of `test/switch_stmt`.
