### PR TITLE
Take back what was handed to an optional parameter

### DIFF
--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -582,6 +582,12 @@ struct ExBinding {
 }
 
 /// A branch condition that tests a `_nullable` pointer against null.
+#[derive(Default)]
+struct NullableGhosts {
+    before: Vec<Doc>,
+    after: Vec<Doc>,
+}
+
 struct NullableGuard {
     /// The pointer being tested.
     pointer: Rc<Expr>,
@@ -3683,7 +3689,152 @@ impl<'a> Emitter<'a> {
         })
     }
 
+    /// Strip casts and parentheses down to the null pointer constant, if that
+    /// is what an argument is.
+    fn is_null_constant(e: &Expr) -> bool {
+        match &e.val {
+            ExprT::Cast(inner, _) => Self::is_null_constant(inner),
+            ExprT::IntLit(n, _) => **n == BigInt::ZERO,
+            _ => false,
+        }
+    }
+
+    /// The ghost steps a statement owes around a call that supplies an
+    /// argument for a `_nullable` parameter, before the call and after it.
+    ///
+    /// A callee that takes an optional pointer states its half of the bargain
+    /// under a guard: it asks for `unless_null p (..)` and gives back
+    /// `unless_null p (..)`. That is right for the callee and wrong for the
+    /// caller, which knows which side of the test its own argument is on and
+    /// wants the resource, or nothing, rather than a guarded maybe. The guard
+    /// is deliberately opaque -- see `Pulse.Lib.C.Nullable` -- so neither end
+    /// of it opens by itself, and the resource the caller handed over stays
+    /// out of reach afterwards. Nothing about that is conditional: it happens
+    /// on every call that supplies or declines an optional parameter, which in
+    /// such code is most calls between conversions.
+    ///
+    /// Declining is the easy half: `p` is `null`, the resource is nothing, and
+    /// the elimination just discards the guard.
+    ///
+    /// Supplying takes a fact rather than a resource. `elim_unless_null_ref`
+    /// needs to know the pointer is not null, and the only way to learn that
+    /// is from the resource itself -- which is exactly what is inside the
+    /// guard. So the fact is established *before* the call, while the resource
+    /// is still unguarded, and carried across the call as a pure proposition.
+    /// Which lemma establishes it depends on what the caller is holding, and
+    /// the callee's parameter mode says: an `_out` parameter is handed
+    /// uninitialized storage, anything else an initialized cell.
+    fn nullable_arg_ghosts(&mut self, env: &Env, stmt: &Stmt) -> (Vec<Doc>, Vec<Doc>) {
+        let mut ghosts = NullableGhosts::default();
+        self.nullable_arg_ghosts_stmt(env, stmt, &mut ghosts);
+        (ghosts.before, ghosts.after)
+    }
+
+    fn nullable_arg_ghosts_stmt(&mut self, env: &Env, stmt: &Stmt, out: &mut NullableGhosts) {
+        match &stmt.val {
+            StmtT::Assign(l, r) => {
+                self.nullable_arg_ghosts_expr(env, l, out);
+                self.nullable_arg_ghosts_expr(env, r, out);
+            }
+            StmtT::Call(e) | StmtT::Return(Some(e)) => self.nullable_arg_ghosts_expr(env, e, out),
+            StmtT::Let(_, _, e) => self.nullable_arg_ghosts_expr(env, e, out),
+            _ => {}
+        }
+    }
+
+    fn nullable_arg_ghosts_expr(&mut self, env: &Env, e: &Expr, out: &mut NullableGhosts) {
+        match &e.val {
+            ExprT::UnOp(_, a) | ExprT::Cast(a, _) | ExprT::Deref(a) | ExprT::Ref(a) => {
+                self.nullable_arg_ghosts_expr(env, a, out)
+            }
+            ExprT::BinOp(_, a, b) | ExprT::AssignExpr(a, b) => {
+                self.nullable_arg_ghosts_expr(env, a, out);
+                self.nullable_arg_ghosts_expr(env, b, out);
+            }
+            ExprT::FnCall(f, args) => {
+                for a in args.iter() {
+                    self.nullable_arg_ghosts_expr(env, a, out);
+                }
+                let Some(fn_decl) = env.lookup_fn(f) else {
+                    return;
+                };
+                for (i, arg) in args.iter().enumerate() {
+                    let Some(param) = fn_decl.args.get(i) else {
+                        continue;
+                    };
+                    let TypeT::Nullable(inner) = &param.ty.val else {
+                        continue;
+                    };
+                    let inner: Rc<Type> = inner.clone().into();
+                    // Only a plain pointer round-trips today. An optional
+                    // array argument still has to be opened by hand.
+                    if !matches!(
+                        &env.vtype_whnf(inner.into()).val,
+                        TypeT::Pointer(_, PointerKind::Ref | PointerKind::Unknown)
+                    ) {
+                        continue;
+                    }
+                    if Self::is_null_constant(arg) {
+                        out.after
+                            .push(Doc::text("Pulse.Lib.C.Nullable.elim_null_ref null;"));
+                        continue;
+                    }
+                    // Only when PAL is the one holding the resource. Two
+                    // arguments look identical here and are not: a pointer
+                    // whose ownership PAL emitted, which it can take back
+                    // afterwards, and one whose ownership was written by hand
+                    // in the enclosing contract, which it cannot.
+                    //
+                    // `_nullable` is the forwarding case -- an optional
+                    // argument passed straight through from an optional
+                    // parameter, where the caller is in no position to say
+                    // which way the test goes, that being the whole point of
+                    // forwarding it. `_plain` is the hand-written case: PAL
+                    // emits no ownership at all for it, so there is nothing
+                    // here to take back and the enclosing contract's own
+                    // `unless_null` would be eliminated out from under it.
+                    let Ok(arg_ty) = env.infer_expr(arg) else {
+                        continue;
+                    };
+                    if matches!(arg_ty.val, TypeT::Nullable(_) | TypeT::Plain(_)) {
+                        continue;
+                    }
+                    let arg_doc = parens(self.emit_rvalue(env, arg));
+                    let not_null = match param.mode {
+                        ParamMode::Out => "Pulse.Lib.Reference.pts_to_uninit_not_null",
+                        _ => "Pulse.Lib.Reference.pts_to_not_null",
+                    };
+                    out.before.push(
+                        Doc::text(not_null.to_string())
+                            .append(Doc::text(" "))
+                            .append(arg_doc.clone())
+                            .append(Doc::text(";")),
+                    );
+                    out.after.push(
+                        Doc::text("Pulse.Lib.C.Nullable.elim_unless_null_ref ".to_string())
+                            .append(arg_doc)
+                            .append(Doc::text(";")),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn emit_stmt(&mut self, env: &Env, stmt: &Stmt) -> Doc {
+        let (before, after) = self.nullable_arg_ghosts(env, stmt);
+        let mut doc = Doc::nil();
+        for g in before {
+            doc = doc.append(g).append(Doc::hardline());
+        }
+        doc = doc.append(self.emit_stmt_core(env, stmt));
+        for g in after {
+            doc = doc.append(Doc::hardline()).append(g);
+        }
+        doc
+    }
+
+    fn emit_stmt_core(&mut self, env: &Env, stmt: &Stmt) -> Doc {
         annotated(stmt, || {
             match &stmt.val {
                 StmtT::Call(v) => {

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -613,6 +613,13 @@ enum ValNaming<'a> {
     /// Used for function signatures and old-style preds.
     Standard {
         quote: bool,
+        /// Base identifier for generated val names. `None` derives it from the
+        /// expression being described, which is what a signature clause wants:
+        /// the value is named after the parameter it belongs to. A caller that
+        /// describes a parameter's resource through some *other* expression --
+        /// the local the null test binds, say -- has to say which parameter the
+        /// names belong to, or it invents names no signature ever bound.
+        base: Option<Rc<IdentT>>,
         bindings: &'a mut Vec<ExBinding>,
     },
     /// Spec record: val references become `spec_param.field_name`.
@@ -1417,13 +1424,14 @@ impl<'a> Emitter<'a> {
     /// Returns the Doc to use as the val reference in the slprop.
     fn push_val_binding(&mut self, naming: &mut ValNaming, this: &Rc<Expr>, ty: Doc) -> Doc {
         match naming {
-            ValNaming::Standard { quote, bindings } => {
+            ValNaming::Standard {
+                quote,
+                base,
+                bindings,
+            } => {
                 let idx = bindings.len() as u32;
-                let raw = Doc::text(
-                    self.nm
-                        .mangle(&Name::Val(extract_base_ident(this), idx))
-                        .to_string(),
-                );
+                let base_ident = base.clone().unwrap_or_else(|| extract_base_ident(this));
+                let raw = Doc::text(self.nm.mangle(&Name::Val(base_ident, idx)).to_string());
                 let val_name = if *quote {
                     Doc::text("'").append(raw)
                 } else {
@@ -1468,7 +1476,9 @@ impl<'a> Emitter<'a> {
     /// Returns the Doc to use as the val reference in the slprop.
     fn push_val_binding_explicit(&mut self, naming: &mut ValNaming, raw_name: Doc, ty: Doc) -> Doc {
         match naming {
-            ValNaming::Standard { quote, bindings } => {
+            ValNaming::Standard {
+                quote, bindings, ..
+            } => {
                 let val_name = if *quote {
                     Doc::text("'").append(raw_name)
                 } else {
@@ -1779,6 +1789,7 @@ impl<'a> Emitter<'a> {
                 if existential {
                     let mut local_naming = ValNaming::Standard {
                         quote: false,
+                        base: None,
                         bindings: &mut local_bindings,
                     };
                     self.emit_type_slprop_inner(
@@ -1834,6 +1845,7 @@ impl<'a> Emitter<'a> {
         let mut props = vec![];
         let mut naming = ValNaming::Standard {
             quote: false,
+            base: None,
             bindings: &mut bindings,
         };
         emit_slprops(self, variant, &mut naming, &mut props);
@@ -4658,6 +4670,7 @@ impl<'a> Emitter<'a> {
             let mut props = vec![];
             let mut naming = ValNaming::Standard {
                 quote,
+                base: None,
                 bindings: &mut bindings,
             };
             let this = mk_rvar(name);
@@ -4726,11 +4739,24 @@ impl<'a> Emitter<'a> {
         };
         // A `preserves` names the value with a signature-level implicit, which
         // is in scope in the body; the other modes bind it existentially.
+        //
+        // For a preserved (const) pointer that implicit is the *only* value the
+        // signature will accept back: `preserves unless_null p (.. 'val_p_0)`
+        // asks for the value the caller handed in, not for some value. So the
+        // payload has to name it exactly as the signature does -- off the
+        // parameter, not off the local the null test binds -- and must not
+        // re-quantify it, or the branch gives back an `exists*` where the
+        // signature wanted `'val_p_0` and the join fails.
         let quote = matches!(mode, ParamMode::Const);
+        let base = match mode {
+            ParamMode::Const => Some(extract_base_ident(&guard.pointer)),
+            _ => None,
+        };
         let mut bindings = vec![];
         let mut props = vec![];
         let mut naming = ValNaming::Standard {
             quote,
+            base,
             bindings: &mut bindings,
         };
         self.emit_type_slprop(
@@ -4744,6 +4770,9 @@ impl<'a> Emitter<'a> {
         drop(naming);
         if props.is_empty() {
             return None;
+        }
+        if quote {
+            return Some(parens(mk_star(props)));
         }
         Some(parens(wrap_exists(&bindings, props)))
     }
@@ -5546,6 +5575,7 @@ impl<'a> Emitter<'a> {
                 let mut field_bindings = vec![];
                 let mut naming = ValNaming::Standard {
                     quote: false,
+                    base: None,
                     bindings: &mut field_bindings,
                 };
                 self.emit_type_slprop(
@@ -6785,6 +6815,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: false,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -6817,6 +6848,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: true,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -6835,6 +6867,7 @@ impl<'a> Emitter<'a> {
                     let mut uninit_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: true,
+                        base: None,
                         bindings: &mut uninit_bindings,
                     };
                     self.emit_type_slprop(
@@ -6853,6 +6886,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: false,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -6914,6 +6948,7 @@ impl<'a> Emitter<'a> {
             let mut ret_props = vec![];
             let mut naming = ValNaming::Standard {
                 quote: false,
+                base: None,
                 bindings: &mut ret_bindings,
             };
             self.emit_type_slprop(
@@ -7099,6 +7134,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: false,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -7133,6 +7169,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: true,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -7152,6 +7189,7 @@ impl<'a> Emitter<'a> {
                     let mut uninit_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: true,
+                        base: None,
                         bindings: &mut uninit_bindings,
                     };
                     self.emit_type_slprop(
@@ -7172,6 +7210,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: false,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -7205,6 +7244,7 @@ impl<'a> Emitter<'a> {
         let mut ret_props = vec![];
         let mut naming = ValNaming::Standard {
             quote: false,
+            base: None,
             bindings: &mut ret_bindings,
         };
         self.emit_type_slprop(
@@ -7859,6 +7899,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: true,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(
@@ -7877,6 +7918,7 @@ impl<'a> Emitter<'a> {
                     let mut type_props = vec![];
                     let mut naming = ValNaming::Standard {
                         quote: false,
+                        base: None,
                         bindings: &mut type_bindings,
                     };
                     self.emit_type_slprop(

--- a/test/nullable_out/nullable_out.c
+++ b/test/nullable_out/nullable_out.c
@@ -83,3 +83,56 @@ void opt_fill_pair(_nullable _out _refine(this->lo == 0 && this->hi == 0) struct
         fill_pair(Dst);
     }
 }
+
+/* Supplying and declining an optional parameter, from the caller's side.
+   `opt_write_many` states its two outputs under a guard, which is right for
+   it and wrong for a caller that knows which side of each test its own
+   arguments are on. Handing over a pointer PAL owns and taking it back again
+   is the ordinary shape of a conversion built out of smaller conversions. */
+void forward_one(const uint64_t* Src, _out uint64_t* Dst)
+    _ensures(*Dst == *Src)
+{
+    opt_write_many(Src, Dst, NULL);
+}
+
+/* The other way round, so that neither position is special. */
+void forward_other(const uint64_t* Src, _out uint64_t* Dst)
+    _ensures(*Dst == *Src)
+{
+    opt_write_many(Src, NULL, Dst);
+}
+
+/* Both supplied, and both recovered. */
+void forward_both(const uint64_t* Src, _out uint64_t* First, _out uint64_t* Second)
+    _ensures(*First == *Src)
+    _ensures(*Second == *Src)
+{
+    opt_write_many(Src, First, Second);
+}
+
+/* Neither supplied: the guard has to be discarded twice even though nothing
+   was ever behind it. */
+void forward_neither(const uint64_t* Src)
+{
+    opt_write_many(Src, NULL, NULL);
+}
+
+/* Forwarding an optional parameter onward as an optional parameter. The
+   caller cannot say which way the test goes -- that is what makes it a
+   forward -- so the guard must be passed along untouched rather than opened
+   and closed. */
+void forward_optional(const uint64_t* Src, _nullable _out _refine(*this == *Src) uint64_t* Dst)
+{
+    opt_write_many(Src, Dst, NULL);
+}
+
+/* Supplying the address of a local, which is where a value read back out of
+   a conversion usually lands. */
+void via_local(const uint64_t* Src, _out uint64_t* Dst)
+    _ensures(*Dst == *Src)
+{
+    uint64_t tmp;
+
+    opt_write_many(Src, &tmp, NULL);
+    *Dst = tmp;
+}


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR28 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `nswamy/pal-pr27-nullable-out` — a *stacked* PR. It depends on `nswamy/pal-pr27-nullable-out`, so only the commits listed below are its own; it will be retargeted at `main` once its parents land.

A callee states its half of the bargain under a guard, which is right for the callee and
wrong for its caller — which knows which side of the test its own argument is on and wants
the resource, or nothing, rather than a guarded maybe. Until now a caller that supplied an
optional output never got the storage back, and one that declined was told it had leaked a
resource that was never there. Declining is easy; supplying takes a *fact* — eliminating
the guard needs to know the pointer is not null, and the only evidence is the resource now
inside it — so the fact is established before the call and carried across as a pure
proposition, with the lemma chosen by the callee's parameter mode. Two arguments that look
identical are distinguished: ownership PAL emitted may be taken back, ownership written by
hand in the enclosing contract (a `_nullable` or `_plain` argument) may not. The first
commit fixes the name the preserved payload is given, which has to be the one the signature
will accept.

### Commits

- Name a preserved nullable payload after the parameter
- Take back what was handed to an optional parameter

### Testing

Verified: `make rust lib`, `test/check-template.sh`, `cargo fmt --check`, `clang-format --dry-run --Werror`, and F* verification of `test/nullable_out`, `test/nullable_out_struct`.
