### PR TITLE
Zero an array through a platform memset wrapper

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -1422,6 +1422,43 @@ public:
               }
             }
           }
+          // Zeroing a whole array: `f(arr, N)` where `arr` is an array-typed
+          // lvalue that decays to the pointer argument and `N` is its size in
+          // bytes. The extent lives in the array's own type, so nothing has to
+          // be inferred from the way the count was spelled: `sizeof(s->field)`
+          // and a literal are both accepted, and both are checked against the
+          // type rather than trusted. This is the shape a platform zeroing
+          // wrapper takes on a fixed-size trailing `Reserved` member, which
+          // `memset(ptr, 0, sizeof(T) * n)` below cannot express because a
+          // wrapper taking `void *` has no element type to name.
+          {
+            auto *destObj = c->getArg(0)->IgnoreParenImpCasts();
+            auto destQt = destObj->getType();
+            if (const auto *arrTy = astCtx->getAsConstantArrayType(destQt)) {
+              auto elemQt = arrTy->getElementType();
+              Expr::EvalResult szRes;
+              const bool byteSized =
+                  !elemQt->isIncompleteType() && !elemQt->isDependentType() &&
+                  astCtx->getTypeSizeInChars(elemQt).getQuantity() == 1;
+              const auto arrBytes =
+                  astCtx->getTypeSizeInChars(destQt).getQuantity();
+              if (byteSized && sizeArg->EvaluateAsInt(szRes, *astCtx) &&
+                  szRes.Val.isInt() && szRes.Val.getInt() == arrBytes) {
+                auto elemTy = trQualType(elemQt, destObj->getSourceRange());
+                llvm::SmallString<20> countStr;
+                llvm::APInt(64, arrBytes, true).toStringSigned(countStr);
+                auto countExpr = mk_int_lit(
+                    loc.clone(), mk_bigint(toStr(StringRef(countStr))),
+                    trQualType(astCtx->getSizeType(), e->getSourceRange()));
+                auto zeroExpr =
+                    mk_int_lit(loc.clone(), mk_bigint("0"_rs),
+                               trQualType(elemQt, destObj->getSourceRange()));
+                return mk_memset(std::move(loc), std::move(elemTy),
+                                 trRValue(ptrArg), std::move(zeroExpr),
+                                 std::move(countExpr));
+              }
+            }
+          }
           // The array shape below reads the fill value out of the call, which
           // an alias does not carry, and a wrapper taking `void *` cannot name
           // a byte-sized element type anyway. Rejecting it here keeps an
@@ -1431,7 +1468,8 @@ public:
             reportUnsupported(
                 e->getSourceRange(), loc,
                 "a _memset_zero call is only supported in the form "
-                "f(ptr, sizeof(*ptr)); ",
+                "f(ptr, sizeof(*ptr)) or f(arr, sizeof(arr)) for a "
+                "fixed-size array of a byte-sized element type; ",
                 fd->getName().str());
             return mk_rvalue_err(std::move(loc),
                                  trQualType(c->getType(), c->getSourceRange()));

--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -1359,7 +1359,31 @@ public:
         //   * memset(ptr, 0, sizeof(T) * n)  — zero an array of byte-sized
         //     element type (e.g. uint8_t, char).
         // Non-zero fill values are rejected with a clear diagnostic.
-        if (fd->getName() == "memset" && c->getNumArgs() == 3) {
+        // A platform's zeroing wrapper is the memset intrinsic under another
+        // name and a shorter argument list: `zero_memory(ptr, size)`,
+        // `RtlZeroMemory(ptr, size)`, `bzero(ptr, size)`. Declaring it
+        // `_memset_zero` routes it through the same recognizer, with the fill
+        // value supplied rather than read from the call. Without this the
+        // wrapper translates to an uninterpreted stub, which silently makes
+        // every postcondition about the zeroed object vacuous.
+        bool isMemsetAlias = false;
+        for (auto *attr : fd->attrs()) {
+          if (auto *ann = dyn_cast<AnnotateAttr>(attr);
+              ann && ann->getAnnotation() == "pal-memset-zero" &&
+              ann->args_size() == 0) {
+            isMemsetAlias = true;
+          }
+        }
+        if (isMemsetAlias && c->getNumArgs() != 2) {
+          reportUnsupported(e->getSourceRange(), loc,
+                            "a _memset_zero function must take exactly two "
+                            "arguments (destination, size); ",
+                            fd->getName().str());
+          return mk_rvalue_err(std::move(loc),
+                               trQualType(c->getType(), c->getSourceRange()));
+        }
+        if ((fd->getName() == "memset" && c->getNumArgs() == 3) ||
+            isMemsetAlias) {
           auto *ptrArg = c->getArg(0);
           // Strip implicit void* cast
           if (auto *ic = dyn_cast<ImplicitCastExpr>(ptrArg)) {
@@ -1367,11 +1391,13 @@ public:
               ptrArg = ic->getSubExpr();
             }
           }
-          auto *valArg = c->getArg(1);
-          auto *sizeArg = c->getArg(2)->IgnoreParenImpCasts();
+          auto *valArg = isMemsetAlias ? nullptr : c->getArg(1);
+          auto *sizeArg =
+              c->getArg(isMemsetAlias ? 1 : 2)->IgnoreParenImpCasts();
           Expr::EvalResult valRes;
-          bool valIsZero = valArg->EvaluateAsInt(valRes, *astCtx) &&
-                           valRes.Val.isInt() && valRes.Val.getInt() == 0;
+          bool valIsZero =
+              isMemsetAlias || (valArg->EvaluateAsInt(valRes, *astCtx) &&
+                                valRes.Val.isInt() && valRes.Val.getInt() == 0);
           if (!valIsZero) {
             reportUnsupported(e->getSourceRange(), loc,
                               "memset is only supported with a zero fill value",
@@ -1395,6 +1421,20 @@ public:
                                       trRValue(ptrArg));
               }
             }
+          }
+          // The array shape below reads the fill value out of the call, which
+          // an alias does not carry, and a wrapper taking `void *` cannot name
+          // a byte-sized element type anyway. Rejecting it here keeps an
+          // unrecognized alias call from falling through to an uninterpreted
+          // stub.
+          if (isMemsetAlias) {
+            reportUnsupported(
+                e->getSourceRange(), loc,
+                "a _memset_zero call is only supported in the form "
+                "f(ptr, sizeof(*ptr)); ",
+                fd->getName().str());
+            return mk_rvalue_err(std::move(loc),
+                                 trQualType(c->getType(), c->getSourceRange()));
           }
           if (auto *binOp = dyn_cast<BinaryOperator>(sizeArg)) {
             if (binOp->getOpcode() == BO_Mul) {
@@ -2509,6 +2549,26 @@ public:
                           "internal error: invalid _type encoding"_rs);
         }
         return {};
+      }
+
+      // A `_memset_zero` wrapper is an intrinsic, not a function: every call
+      // to it is rewritten to a whole-object zeroing, so emitting a module for
+      // it would only add an uninterpreted stub that nothing calls. A
+      // definition still translates normally -- the marker only claims what
+      // calls mean, and a body present in this translation unit is code to be
+      // verified like any other.
+      {
+        bool memsetZero = false;
+        for (auto *attr : FD->getAttrs()) {
+          if (auto *ann = dyn_cast<AnnotateAttr>(attr);
+              ann && ann->getAnnotation() == "pal-memset-zero" &&
+              ann->args_size() == 0) {
+            memsetZero = true;
+          }
+        }
+        if (memsetZero && !FD->hasBody()) {
+          return {};
+        }
       }
 
       // Regular function decl

--- a/examples/pal.h
+++ b/examples/pal.h
@@ -42,6 +42,12 @@ __attribute__((annotate("pal-pure"))) _Bool pal_c_assert_enabled(void);
 #define _rec __attribute((annotate("pal-rec")))
 #define _pulse_eager_unfold_predicate __attribute__((annotate("pal-eager-unfold-predicate")))
 #define _pointer_view __attribute__((annotate("pal-pointer-view")))
+/* Marks a platform wrapper around `memset(p, 0, n)` -- zero_memory,
+   RtlZeroMemory, bzero -- so that calls of the form `f(ptr, sizeof(*ptr))`
+   translate to the same whole-object zeroing that a direct memset does. An
+   unmarked wrapper becomes an uninterpreted stub, which makes any later claim
+   about the zeroed object unprovable, or worse, vacuous. */
+#define _memset_zero __attribute__((annotate("pal-memset-zero")))
 #define _decreases(p) __attribute__((annotate("pal-decreases", __capture_args(p))))
 
 #define _inline_pulse(args) _inline_pulse(__capture_args(args))
@@ -86,6 +92,7 @@ __attribute__((annotate("pal-pure"))) _Bool pal_c_assert_enabled(void);
 #define _rec
 #define _pulse_eager_unfold_predicate
 #define _pointer_view
+#define _memset_zero
 #define _decreases(p)
 
 #define _let(sig, body)

--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -284,19 +284,53 @@ let full_to_mask_seq #t (s: array_spec t) (i: nat)
     assert (array_spec_mask s i)
   end
 
+
+// The private cell write the fill below is built on. It is `array_write`'s
+// body, repeated here because `array_write` is declared after `memset` in the
+// interface and a module must define its interface's members in order.
+fn fill_cell u#a (#t: Type u#a) (a: array t) (i: SZ.t) (v: t)
+  (#s: erased (array_spec t) { array_spec_mask s (SZ.v i) })
+  requires array_pts_to a 1.0R s
+  ensures exists* sn. array_pts_to a 1.0R sn ** pure (sn == array_spec_upd s (SZ.v i) v)
+{
+  unfold array_pts_to a 1.0R s;
+  A.mask_write a i v;
+  let sn = hide (array_spec_upd s (SZ.v i) v);
+  A.mask_mext a (to_mask sn);
+  A.mask_vext a (to_seq sn);
+  fold (array_pts_to a 1.0R sn);
+  ()
+}
+
+// The cells are written one at a time rather than through
+// `Pulse.Lib.Array.fill`, because `fill` goes through `from_mask`, which wants
+// every cell to already hold a value. `array_write` needs only that the cell is
+// in the mask, so the loop covers storage that has not been written yet -- see
+// the note on `memset` in the interface.
 fn memset (#t: Type0) (a: array t) (v: t) (n: SZ.t)
-  (#s: erased (array_spec t) { array_spec_full s /\ array_spec_len s == SZ.v n })
+  (#s: erased (array_spec t) { array_spec_full_mask s /\ array_spec_len s == SZ.v n })
   requires array_pts_to a 1.0R s
   ensures array_pts_to_full a 1.0R (array_spec_zeroed t (SZ.v n) v)
 {
-  unfold array_pts_to a 1.0R s;
-  Classical.forall_intro (Classical.move_requires (full_to_mask_seq s));
-  A.from_mask a;
-  A.pts_to_len a;
-  fill n a v;
-  A.to_mask a;
-  mask_mext a (to_mask (array_spec_zeroed t (SZ.v n) v));
-  mask_vext a (to_seq (array_spec_zeroed t (SZ.v n) v));
+  let mut i = 0sz;
+  while (SZ.lt (!i) n)
+  invariant exists* vi sp.
+    R.pts_to i vi **
+    array_pts_to a 1.0R sp **
+    pure (SZ.v vi <= SZ.v n /\
+          array_spec_len sp == SZ.v n /\
+          array_spec_full_mask sp /\
+          (forall (j:nat). j < SZ.v vi ==> array_spec_initd sp j /\ array_spec_idx sp j == v))
+  decreases (SZ.v n - SZ.v !i)
+  {
+    let vi = !i;
+    fill_cell a vi v;
+    i := SZ.add vi 1sz;
+  };
+  with sf. assert array_pts_to a 1.0R sf;
+  unfold array_pts_to a 1.0R sf;
+  A.mask_mext a (to_mask (array_spec_zeroed t (SZ.v n) v));
+  A.mask_vext a (to_seq (array_spec_zeroed t (SZ.v n) v));
   fold array_pts_to a 1.0R (array_spec_zeroed t (SZ.v n) v);
 }
 
@@ -340,6 +374,7 @@ fn array_write u#a (#t: Type u#a) (a: array t) (i: SZ.t) (v: t)
   fold (array_pts_to a 1.0R s');
   ()
 }
+
 
 fn array_assign_ret u#a (#t: Type u#a) (a: array t) (i: SZ.t) (v: t)
   (#s: erased (array_spec t) { array_spec_mask s (SZ.v i) })

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -221,13 +221,18 @@ fn calloc_array u#a (#a:Type u#a) {| small_type u#a |} {| has_zero_default a |} 
   ensures freeable_array r
   ensures exists* y. array_pts_to r 1.0R y ** pure (y == array_spec_zeroed a (SZ.v sz) zero_default)
 
-// Fill every cell of a fully-initialized array with `v` (C `memset`).
+// Fill every cell of an array with `v` (C `memset`).
 // Only byte-sized element types are translated to this (the transpiler rejects
 // multi-byte element types), so an element-wise fill matches C's byte-wise
-// semantics. The array must already be fully masked and initialized: array
-// function parameters satisfy this (`array_pts_to_full`).
+// semantics.
+//
+// The array must be owned over its whole extent -- `array_spec_full_mask` --
+// but need not already hold values. Zeroing storage that has not been written
+// yet is what a `Reserved` member of a structure under construction needs, and
+// requiring initialization there would be requiring the caller to write the
+// bytes twice. Every cell is overwritten, so nothing uninitialized is read.
 fn memset (#t: Type0) (a: array t) (v: t) (n: SZ.t)
-  (#s: erased (array_spec t) { array_spec_full s /\ array_spec_len s == SZ.v n })
+  (#s: erased (array_spec t) { array_spec_full_mask s /\ array_spec_len s == SZ.v n })
   requires array_pts_to a 1.0R s
   ensures array_pts_to_full a 1.0R (array_spec_zeroed t (SZ.v n) v)
 

--- a/test/memset/memset.c
+++ b/test/memset/memset.c
@@ -65,3 +65,35 @@ int zero_local(void)
     memset(&t, 0, sizeof(t));
     return t.a;
 }
+
+// A platform wrapper around memset. Declaring it `_memset_zero` says that a
+// call `f(ptr, size)` is the zero fill, so calls translate to the same
+// whole-object write as a direct memset rather than to an uninterpreted stub.
+_memset_zero
+void plat_zero(void *buffer, size_t size);
+
+void zero_triple_via_wrapper(struct triple *s)
+    _ensures(s->a == 0)
+    _ensures(s->c == 0)
+{
+    plat_zero(s, sizeof(*s));
+}
+
+// The wrapper composes with a later field write, exactly as memset does: the
+// field written afterwards holds its new value and the untouched ones are 0.
+void zero_then_set(struct triple *s)
+    _ensures(s->a == 7)
+    _ensures(s->b == 0)
+{
+    plat_zero(s, sizeof(struct triple));
+    s->a = 7;
+}
+
+// Zeroing a local through the wrapper, matching `zero_local` above.
+int zero_local_via_wrapper(void)
+    _ensures(return == 0)
+{
+    struct triple t;
+    plat_zero(&t, sizeof(t));
+    return t.a;
+}


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR30 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `nswamy/pal-pr10-array-init-lemmas` — a *stacked* PR. It depends on `nswamy/pal-pr10-array-init-lemmas`, so only the commits listed below are its own; it will be retargeted at `main` once its parents land.

Real code calls a platform zeroing wrapper — `RtlZeroMemory`, `bzero`, a project's own —
which takes `(destination, size)` and defeats the `memset` recognizer, so the call became
an uninterpreted stub and nothing in the signature related the `void *` back to the
object being zeroed. `_memset_zero` marks such a declaration; `f(ptr, sizeof(*ptr))` and
`f(arr, N)` (with the extent checked against the array's own type, not trusted) translate
exactly as a direct `memset` does, and any other shape is a diagnostic rather than a
fallback to the stub the marker exists to avoid. `Pulse.Lib.C.Array.memset` also drops its
`array_spec_full` requirement — storage under construction cannot satisfy it — to
`array_spec_full_mask`, writing cells with `array_write` instead of `fill`.

### Commits

- Let a platform wrapper stand in for memset
- Zero a whole array through the memset intrinsic

### Testing

Verified: `make rust lib`, `test/check-template.sh`, `cargo fmt --check`, `clang-format --dry-run --Werror`, and F* verification of `test/memset`.
