### PR TITLE
emit: sequence a unit after a conditional that names its join state

### DIFF
--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -4399,6 +4399,18 @@ impl<'a> Emitter<'a> {
             doc = doc.append(Doc::line().append(self.emit_stmt(&env, stmt)));
             env.push_stmt(stmt);
             idx += 1;
+            // A conditional that names its own join state cannot be the last
+            // thing in a block: Pulse would then have two postconditions for
+            // it -- the annotated one and the one the enclosing signature
+            // already fixed -- and rejects the pair rather than reconciling
+            // them. Sequencing a unit after it keeps the annotation local to
+            // the join, which is the only place it says anything.
+            if idx == stmts.len()
+                && let StmtT::If { ensures, .. } = &stmt.val
+                && !ensures.is_empty()
+            {
+                doc = doc.append(Doc::line().append("()"));
+            }
         }
         doc
     }


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR31 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `main`. Depends on nothing; reviewable on its own.

Pulse rejects an annotated conditional in tail position: the annotation and the enclosing
signature's postcondition are two postconditions for the same term. Sequencing a unit after
it keeps the annotation local to the join, which is the only place it constrains anything.

### Commits

- emit: sequence a unit after a conditional that names its join state

### Testing

No test directory of its own — this is an enabler whose effect shows up in another PR's fixture, a `pulse/` library lemma, or a `tests-todo` reproducer. Verified with a full `make test -j8` (1372 modules, 0 errors) to confirm it regresses nothing.
