### PR TITLE
Add a reproducer for a scalar write stranding a deep predicate

### DIFF
--- a/examples/tests-todo/nested_scalar_write_retarget.c
+++ b/examples/tests-todo/nested_scalar_write_retarget.c
@@ -1,0 +1,62 @@
+// Tests-todo: writing a scalar field of a nested aggregate strands the
+// enclosing struct's deep predicate at the pre-write value.
+//
+// `mark_done` writes one scalar, three levels down: outer struct, anonymous
+// union, inner struct. The write itself is fine. What is not fine is what the
+// caller is left holding.
+//
+// A struct with a pointer member gets a deep predicate `struct_outer__pred`
+// that is *indexed by the whole struct value* but only owns what the pointer
+// members point at. So after the write there are two chunks: a `pts_to` at the
+// post-write value, and a deep predicate still indexed at the pre-write value.
+// The prover matches the stale one first and reports
+//
+//   Could not prove equality of
+//     `pts_to var_o (Mkstruct_outer ... (Field_Outer_anon_1__Parse
+//                     (Mkstruct_inner ... (int32_to_uint8 3l))))`
+//     `pts_to var_o val_o_0`
+//
+// which reads like a disagreement about the write and is really a disagreement
+// about the index.
+//
+// Delete the `Buffer` member and this file verifies: with no pointer members
+// the deep predicate has nothing to own, and the index never matters. That is
+// the whole of the difference. (Dropping the member also renumbers the
+// anonymous union to `___unnamed1`, so the precondition below has to follow;
+// nothing else changes.)
+//
+// The fix belongs in PAL: index the deep predicate by only the
+// ownership-relevant projection of the struct -- its pointer members -- so a
+// write to any other member cannot move it. Today the workaround is a
+// hand-written ghost step that unfolds at the old index, rewrites the pointer
+// members, and folds at the new one; it is a theorem, but one per struct.
+//
+// The union-arm precondition below is a separate, known limitation: an
+// untagged union has no discriminant, so which arm is live has to be said.
+#include "pal.h"
+#include <stdint.h>
+
+struct Inner
+{
+    uint32_t Count;
+    uint8_t State;
+};
+
+struct Outer
+{
+    uint32_t* Buffer;
+    uint32_t Tag;
+    union {
+        struct Inner Parse;
+        uint32_t Other;
+    };
+};
+
+void
+mark_done(struct Outer* o)
+    _requires(_inline_pulse(
+        pure (Union_Outer_anon_1.Field_Outer_anon_1__Parse?
+                ((!$(o)).Struct_Outer.struct_outer___unnamed2))))
+{
+    o->Parse.State = 3;
+}


### PR DESCRIPTION
Part of the upstreaming of `nswamy/pal-c-project-integration` (PR32 of 35 PRs) — see `PR_PLAN.md` on that branch for the whole plan and the dependency graph.

**Base:** `main`. Depends on nothing; reviewable on its own.

A reproducer under `examples/tests-todo/`, no product change. A struct's deep predicate is
indexed by the whole struct value but owns only what its pointer members point at, so
writing any other member moves the index without changing the ownership; the stale chunk
is what the prover matches first, and the failure is reported as an inexplicable
inequality of two `pts_to` terms. The reproducer narrows the trigger to a single pointer
member: with it the file fails, and deleting it — keeping the union, the nesting and the
write — makes the identical file verify. The fix is to index the predicate by the
ownership-relevant projection of the struct rather than the whole value.

### Commits

- Add a reproducer for a scalar write stranding a deep predicate

### Testing

No test directory of its own — this is an enabler whose effect shows up in another PR's fixture, a `pulse/` library lemma, or a `tests-todo` reproducer. Verified with a full `make test -j8` (1372 modules, 0 errors) to confirm it regresses nothing.
