### PR TITLE
Merge the enumerator flag when merging global declarations

### DIFF
--- a/src/pass/merge.rs
+++ b/src/pass/merge.rs
@@ -277,12 +277,18 @@ pub fn merge(diags: &mut Diagnostics, tu: &mut TranslationUnit) {
             if let DeclT::GlobalVar(later_gv) = &later.val
                 && let DeclT::GlobalVar(earlier_gv) = &tu.decls[dst].val
             {
+                // Being an enumerator is fixed for the entity, so the two
+                // declarations cannot disagree: C forbids redeclaring an
+                // enumerator, and one sharing a name with a global is a
+                // redeclaration clang rejects before we see it.
+                debug_assert_eq!(earlier_gv.is_enum_constant, later_gv.is_enum_constant);
                 let merged = GlobalVar {
                     name: later_gv.name.clone(),
                     ty: later_gv.ty.clone(),
                     init: later_gv.init.clone().or_else(|| earlier_gv.init.clone()),
                     is_pure: earlier_gv.is_pure || later_gv.is_pure,
                     opaque_to_smt: earlier_gv.opaque_to_smt || later_gv.opaque_to_smt,
+                    is_enum_constant: later_gv.is_enum_constant,
                 };
                 // Point at whichever declaration defines the object.
                 let loc = if later_gv.init.is_none() && earlier_gv.init.is_some() {


### PR DESCRIPTION
`main` did not compile:

    error[E0063]: missing field `is_enum_constant` in initializer of
    `ir::GlobalVar` --> src/pass/merge.rs:280:30

Two independent changes collided without touching each other's lines, so git merged them cleanly and only a build caught it. One added the field-wise `GlobalVar` literal that merges a global's declarations; the other added `is_enum_constant` to `GlobalVar`, leaving that literal incomplete.

Take the flag from the later declaration, as `name` and `ty` already do. The neighbouring `is_pure` and `opaque_to_smt` are OR-ed because either declaration may carry information the other lacks, but being an enumerator is fixed for the entity rather than accumulated across its declarations, so OR-ing would suggest the two could legitimately disagree.

They cannot, and the assertion says so: C forbids redeclaring an enumerator, and an enumerator sharing a name with a global is a redeclaration clang rejects before this pass runs. The merge path is therefore unreachable for enumerators today; the assertion is what keeps the plain `later_gv` honest if that ever changes.