### PR TITLE
emit: fix syntax error for function pointers with multiple ownership groups 

### DIFF
--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -758,30 +758,6 @@ fn nary_tuple_proj(base: Doc, i: usize, n: usize) -> Doc {
     parens(Doc::text(format!("Mktuple{n}?._{} ", i + 1)).append(base))
 }
 
-/// Like `wrap_exists`, but instead of introducing a fresh `exists* v1 v2. ..`
-/// binder for `bindings`, binds each name via `let vi = <proj_i> in ..` to a
-/// caller-supplied projection expression (one projection per binding, in
-/// order). Used for a wrapper's `requires`-side existential parameter
-/// ownership: turning it into `let`s (rather than an `exists*`) keeps it out
-/// of the wrapper's own elaborated *type*, so `pre_of`/`post_of`'s
-/// higher-order unification isn't defeated by a Pulse-inserted hidden
-/// implicit binder (see `Pulse.Lib.C.FuncPtr.fsti`'s witness-parameter doc).
-fn wrap_witness(bindings: &[ExBinding], props: Vec<Doc>, projs: &[Doc]) -> Doc {
-    let star = mk_star(props);
-    if bindings.is_empty() {
-        return star;
-    }
-    let let_prefix = Doc::concat(bindings.iter().zip(projs.iter()).map(|(b, proj)| {
-        Doc::text("let ")
-            .append(b.name.clone())
-            .append(" = ")
-            .append(proj.clone())
-            .append(" in")
-            .append(Doc::hardline())
-    }));
-    let_prefix.append(star)
-}
-
 /// If `ty` is a bare (non-`_plain`, non-`_core_ref`, non-`_nullable`) pointer
 /// type, return its pointee type -- this is exactly the pointer shape whose
 /// ownership `emit_fnptr_spec_core` witnesses via an explicit `erased c`
@@ -6501,10 +6477,11 @@ impl<'a> Emitter<'a> {
         // Requires-side existential ownership groups (e.g. a plain pointer
         // parameter's pointee value), one per Regular/Consumed/Out arg.
         // Deferred until after this loop: their bindings are combined into
-        // ONE explicit `y_fp: erased c` wrapper parameter (via
-        // `wrap_witness`) instead of independent `exists*`s, which Pulse
-        // would otherwise open as hidden implicit binders and break
-        // `pre_of`/`post_of`'s higher-order unification (F* Error 189; see
+        // ONE explicit `y_fp: erased c` wrapper parameter, bound by `let`s
+        // rather than independent `exists*`s. `let`s keep the bindings out of
+        // the wrapper's own elaborated *type*; `exists*`s would be opened by
+        // Pulse as hidden implicit binders and break `pre_of`/`post_of`'s
+        // higher-order unification (F* Error 189; see
         // `Pulse.Lib.C.FuncPtr.fsti`). Ensures-side `exists*`s aren't part of
         // the wrapper's arrow type, so they keep using `wrap_exists`.
         let mut req_witness_groups: Vec<(Vec<ExBinding>, Vec<Doc>)> = vec![];
@@ -6598,34 +6575,43 @@ impl<'a> Emitter<'a> {
             }
         }
         // Combine every requires-side existential group's bindings (in arg
-        // order) into a single flat witness type tuple `c`, and re-express
-        // each group's props via `let`s projecting out of ONE explicit
-        // `y_fp: erased c` wrapper parameter (see comment above).
+        // order) into a single flat witness type tuple `c`, and bind them all
+        // with `let`s projecting out of ONE explicit `y_fp: erased c` wrapper
+        // parameter (see comment above).
         let witness_count: usize = req_witness_groups.iter().map(|(b, _)| b.len()).sum();
         let witness_ty_docs: Vec<Doc> = req_witness_groups
             .iter()
             .flat_map(|(b, _)| b.iter().map(|eb| eb.ty.clone()))
             .collect();
         let witness_domain = fnptr_domain_doc(witness_ty_docs);
-        {
+        // Every group's `let`s are hoisted into ONE prefix placed in front of
+        // the whole `requires` conjunction, rather than each group carrying
+        // its own. A `let` is a term-level binder, so it cannot appear as the
+        // right operand of `**`: emitting it per group parses only while
+        // there is a single group, and is a syntax error from two groups on.
+        // Hoisting also keeps every witness binding in scope for the trailing
+        // `pure` conjunct below.
+        let witness_let_prefix = {
             let witness_base = parens(Doc::text("reveal y_fp"));
             let mut widx = 0usize;
+            let mut lets: Vec<Doc> = vec![];
             for (bindings, props) in req_witness_groups {
-                if bindings.is_empty() {
-                    requires_props.push(mk_star(props));
-                    continue;
+                for b in &bindings {
+                    let proj = nary_tuple_proj(witness_base.clone(), widx, witness_count);
+                    widx += 1;
+                    lets.push(
+                        Doc::text("let ")
+                            .append(b.name.clone())
+                            .append(" = ")
+                            .append(proj)
+                            .append(" in")
+                            .append(Doc::hardline()),
+                    );
                 }
-                let group_projs: Vec<Doc> = bindings
-                    .iter()
-                    .map(|_| {
-                        let p = nary_tuple_proj(witness_base.clone(), widx, witness_count);
-                        widx += 1;
-                        p
-                    })
-                    .collect();
-                requires_props.push(wrap_witness(&bindings, props, &group_projs));
+                requires_props.push(mk_star(props));
             }
-        }
+            Doc::concat(lets)
+        };
         // `preserves` (const params) hold across the call, so they belong in
         // both the pre and the post.
         requires_props.extend(preserves_props.iter().cloned());
@@ -6710,7 +6696,11 @@ impl<'a> Emitter<'a> {
         // Inline pre/post slprops (bound over the tuple domain `x_fp` via the
         // same projection prefix), to be spliced directly into the `__fp`
         // wrapper's `requires`/`ensures` instead of being named `unfold let`s.
-        let pre_expr = parens(bind_prefix(&name_docs).append(pre_body));
+        let pre_expr = parens(
+            bind_prefix(&name_docs)
+                .append(witness_let_prefix)
+                .append(pre_body),
+        );
         let post_expr = parens(bind_prefix(&name_docs).append(post_body));
 
         FnPtrSpecCore {

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -1080,6 +1080,65 @@ void use_mk_itemx(void)
     destroy_via_field(it);
 }
 
+/* ---- Multiple ownership groups across a function pointer ----
+   Each callback below varies ONE thing: how many parameters contribute an
+   ownership group (a requires-side existential). Parameter count is held
+   separate from group count on purpose, so a failure can be attributed to
+   one or the other.
+
+     mo_one    1 owned param              -> 1 group
+     mo_scalar 2 params, 1 pointer        -> 1 group (a by-value scalar
+                                             emits no existential binder)
+     mo_two    2 owned params             -> 2 groups
+     mo_three  3 owned params             -> 3 groups
+
+   Every address-taken function gets a `Funcptr_<g>` wrapper whose
+   requires-side ownership is carried by ONE explicit `y_fp: erased c`
+   witness parameter, with each group's props recovered by projecting out of
+   it (see emit.rs `emit_fnptr_spec_core`). `mo_one`/`mo_scalar` are the
+   controls for that machinery at one group; `mo_two`/`mo_three` exercise it
+   at two and three. */
+
+struct mo_a { int32_t x; };
+struct mo_b { int32_t y; };
+
+int32_t mo_one(struct mo_a *p)
+    _ensures(return == p->x)
+{
+    return p->x;
+}
+
+int32_t mo_scalar(struct mo_a *p, int32_t k)
+    _requires(p->x > 0 && p->x < 100 && k > 0 && k < 100)
+{
+    return p->x + k;
+}
+
+int32_t mo_two(struct mo_a *p, struct mo_b *q)
+    _requires(p->x > 0 && p->x < 100 && q->y > 0 && q->y < 100)
+{
+    return p->x + q->y;
+}
+
+int32_t mo_three(struct mo_a *p, struct mo_b *q, struct mo_a *r)
+    _requires(p->x > 0 && p->x < 100 && q->y > 0 && q->y < 100
+              && r->x > 0 && r->x < 100)
+{
+    return p->x + q->y + r->x;
+}
+
+/* Address-taken through a const ops table — the shape real drivers use. */
+struct mo_ops {
+    int32_t (*f1)(struct mo_a *);
+    int32_t (*fs)(struct mo_a *, int32_t);
+    int32_t (*f2)(struct mo_a *, struct mo_b *);
+    int32_t (*f3)(struct mo_a *, struct mo_b *, struct mo_a *);
+};
+
+const struct mo_ops the_mo_ops = {
+    .f1 = mo_one, .fs = mo_scalar, .f2 = mo_two, .f3 = mo_three
+};
+
 #if 0
 
 /* [DEFERRED] Indirect recursion through a function pointer. Taking the


### PR DESCRIPTION
## Problem

A function pointer whose callback owns **two or more** pointer parameters emitted
Pulse that does not parse:

```
* Error 168 at out/Funcptr_mo_two.fst(15,9-15,9): Syntax error
```

`emit_fnptr_spec_core` binds a callback's requires-side ownership groups with
`let`s projecting out of a single `y_fp: erased c` witness parameter. Those
`let`s were emitted *per group* by `wrap_witness`, and `mk_star` then joined the
groups with `**`. Since a `let` is a term-level binder, it cannot appear as the
right operand of `**`:

```
(let val_p_0 = (fst (reveal y_fp)) in
  (P_p) **
  let val_q_0 = (snd (reveal y_fp)) in     <-- syntax error
  (P_q) ** (pure ..))
```

With one group the `let` is leftmost and its body swallows the whole
conjunction, so it parsed. From two groups on it did not. Translation itself was
clean — `TranslationErrors.fst` was empty and PAL emitted no diagnostics — so the
breakage only surfaced at F*.

This is the shape real driver code uses: a `const` ops table holding callbacks
that take more than one owned pointer.

## Fix

Hoist every group's `let`s into a single prefix in front of the whole `requires`
conjunction, alongside the argument-binding prefix that `bind_prefix` already
emits:

```
requires (let var_p = (fst x_fp) in
    let var_q = (snd x_fp) in
    let val_p_0 = (fst (reveal y_fp)) in
    let val_q_0 = (snd (reveal y_fp)) in
    (((pts_to var_p #1.0R val_p_0) ** (struct_mo_a__pred (!var_p) 1.0R)) **
      ((pts_to var_q #1.0R val_q_0) ** (struct_mo_b__pred (!var_q) 1.0R)) **
      (pure ..)))
```

Parenthesizing each group in place also fixes the parse, but closes each `let`
before the trailing `pure` conjunct. Hoisting keeps every witness binding in
scope exactly as the working single-group case does today, and matches the
existing `bind_prefix` idiom.

`wrap_witness` had no remaining caller and is removed. Its rationale for using
`let`s rather than `exists*` here — keeping the bindings out of the wrapper's
elaborated type so `pre_of`/`post_of`'s higher-order unification isn't defeated
by a Pulse-inserted hidden implicit binder (F* Error 189) — is folded into the
comment on `req_witness_groups`.

**The ensures side is deliberately unchanged.** `wrap_exists` produces the same
shape (`A ** exists* y. B ** C`), but that is not a bug: `exists*` is an slprop
connective, so it parses, and it is equivalent under
`(exists* y. Q) ** R == exists* y. (Q ** R)` for fresh `y`. Confirmed
empirically — patching only the requires side made the module verify.

## Tests

New cases in `test/func_pointer/func_pointer.c` vary the number of *ownership
groups* while holding parameter count separate, so the two cannot be confused:

| callback | owned params | ownership groups | before | after |
|---|---|---|---|---|
| `mo_one(struct mo_a *p)` | 1 | 1 | pass | pass |
| `mo_scalar(struct mo_a *p, int32_t k)` | 1 (+ by-value scalar) | 1 | pass | pass |
| `mo_two(struct mo_a *p, struct mo_b *q)` | 2 | 2 | **Error 168** | pass |
| `mo_three(struct mo_a *p, struct mo_b *q, struct mo_a *r)` | 3 | 3 | **Error 168** | pass |

`mo_one` and `mo_scalar` are no-regression controls; `mo_scalar` also shows the
defect tracks ownership groups rather than arity. The callbacks are address-taken
through a `const struct mo_ops` table, matching the real-world shape. `mo_three`
additionally covers the arity-3 witness tuple, which uses `MktupleN?._i` rather
than `fst`/`snd`.

The two commits are kept separate: `eb7b336` adds the failing tests, `f07336f`
fixes the emitter.

## Validation

- `make test -j8` green, including `cargo fmt --check` and `clang-format`.
- Clean from-scratch rebuild of `test/func_pointer`: 191 modules verified, zero
  errors.
- No other test's expected output changed.