### PR TITLE
Bump F* nightly to 2026-08-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ it passes, the implementation satisfies the spec. More availabe at [`examples/`]
 | LLVM dev headers | 20.x | `llvm-config`, `libclang-cpp20-dev`, `libclang-20-dev` |
 | g++ | recent | builds the C++ FFI ([`cpp/impl.cpp`](cpp/impl.cpp)) |
 | Rust | 2024 edition | compiles the PAL binary |
-| F\*/Pulse | nightly 2026-08-12 | verifies generated `.fst` output |
+| F\*/Pulse | nightly 2026-08-24 | verifies generated `.fst` output |
 
 ### Setup (Ubuntu / Debian)
 

--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-17 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-24 "$@"

--- a/pulse/Pulse.Lib.C.Ref.fsti
+++ b/pulse/Pulse.Lib.C.Ref.fsti
@@ -102,7 +102,9 @@ ensures r |->? Frac p (Some x)
   introduce exists* v. (r |-> Frac p v) ** pure (Some x == Some v)
   with x;
   rewrite (exists* (v:a). (r |-> Frac p v) ** pure (Some x == Some v)) as (maybe_pts_to r #p (Some x));
-  rewrite (maybe_pts_to r #p (Some x)) as (r |->? Frac p (Some x));
+  rewrite (maybe_pts_to r #p (Some x)) as (maybe_pts_to r #(1.0R *. p) (Some x));
+  fold (pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) (Some x);
+  rewrite ((pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) (Some x)) as (r |->? Frac p (Some x));
 }
 
 ghost
@@ -111,7 +113,9 @@ requires pure (is_null r)
 ensures r |->? Frac p None
 {
   rewrite (pure (None #a == None #a)) as (maybe_pts_to r #p None);
-  rewrite (maybe_pts_to r #p None) as (r |->? Frac p None);
+  rewrite (maybe_pts_to r #p None) as (maybe_pts_to r #(1.0R *. p) None);
+  fold (pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) None;
+  rewrite ((pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) None) as (r |->? Frac p None);
 }
 
 

--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -2255,7 +2255,7 @@ fn emit_unop(env: &Env, op: UnOp, ty: MaybeRc<Type>) -> Option<Doc> {
                 Doc::text(format!("{}.minus", modu))
             }
         }
-        (UnOp::Neg, TypeT::SpecInt | TypeT::SpecNat) => Doc::text("op_Minus"),
+        (UnOp::Neg, TypeT::SpecInt | TypeT::SpecNat) => Doc::text("op_Tilde_Minus"),
         (UnOp::Neg, TypeT::Float { width }) => Doc::text(format!("{}_neg", get_float_mod(width)?)),
         (UnOp::Neg, _) => return None,
         (UnOp::BitNot, TypeT::Int { signed, width }) => {


### PR DESCRIPTION
Adapt to two upstream changes:

- Prims renamed prefix unary integer negation from `-` (`op_Minus`) to `~-` (`op_Tilde_Minus`); `op_Minus` is now binary subtraction. Emit `op_Tilde_Minus` for spec-int/spec-nat negation.

- The reverse-fold `rewrite` through the `pts_to_nullable_frac` instance no longer reduces the instance projection in `intro_non_null` / `intro_null`. Fold through the intermediate `pts_to_nullable_pts_to` instance form so the rewrite discharges.