### PR TITLE
Parenthesize the null function pointer literal

### DIFF
--- a/src/pass/emit.rs
+++ b/src/pass/emit.rs
@@ -2548,9 +2548,11 @@ impl<'a> Emitter<'a> {
                         TypeT::Pointer(_, PointerKind::Core) if **val == BigInt::ZERO => {
                             Doc::text("core_null")
                         }
-                        TypeT::FnPtr { .. } if **val == BigInt::ZERO => {
-                            Doc::text("Pulse.Lib.C.FuncPtr.null _ _")
-                        }
+                        TypeT::FnPtr { .. } if **val == BigInt::ZERO => naryfn([
+                            Doc::text("Pulse.Lib.C.FuncPtr.null"),
+                            Doc::text("_"),
+                            Doc::text("_"),
+                        ]),
                         _ => {
                             self.report(
                                 format!("unsupported integer literal type for {}", val),
@@ -2853,7 +2855,11 @@ impl<'a> Emitter<'a> {
                             }
                         }
                         (_, TypeT::FnPtr { .. }) if matches!(&val.val, ExprT::IntLit(n, _) if **n == BigInt::ZERO) => {
-                            Doc::text("Pulse.Lib.C.FuncPtr.null _ _")
+                            naryfn([
+                                Doc::text("Pulse.Lib.C.FuncPtr.null"),
+                                Doc::text("_"),
+                                Doc::text("_"),
+                            ])
                         }
                         // (TypeT::Pointer { to:t1, kind:k1 }, TypeT::Pointer { to:t2, kind:k2 }) if t1 == t2 => todo!(),
                         // (TypeT::Pointer { to, kind }, TypeT::SLProp) => todo!(),

--- a/test/func_pointer/func_pointer.c
+++ b/test/func_pointer/func_pointer.c
@@ -223,6 +223,47 @@ int32_t fp_spec_null(binop f)
     return f != 0;
 }
 
+/* ---- null in argument position ----
+   `null` takes two explicit type arguments, so the emitted term is an
+   application and must be parenthesized to survive juxtaposition at a call
+   site. `take_cb` deliberately does not call its callback, so no `is_valid`
+   witness is needed and the proof stays trivial. */
+
+int32_t take_cb(int32_t x, int32_t (*f)(int32_t))
+    _ensures(return == x)
+{
+    return x;
+}
+
+/* NULL as an argument. */
+int32_t pass_null_cb(int32_t x)
+    _ensures(return == x)
+{
+    return take_cb(x, NULL);
+}
+
+/* Bare `0` as an argument. */
+int32_t pass_zero_cb(int32_t x)
+    _ensures(return == x)
+{
+    return take_cb(x, 0);
+}
+
+/* Explicit cast to the function-pointer type as an argument. */
+int32_t pass_cast_cb(int32_t x)
+    _ensures(return == x)
+{
+    return take_cb(x, (int32_t (*)(int32_t))0);
+}
+
+/* Via a local; this path already worked, keep it covered. */
+int32_t pass_local_cb(int32_t x)
+    _ensures(return == x)
+{
+    int32_t (*f)(int32_t) = NULL;
+    return take_cb(x, f);
+}
+
 /* ---- calling: arities / void ---- */
 
 /* Zero-arg / `void`-return callback. */


### PR DESCRIPTION
`Pulse.Lib.C.FuncPtr.null` takes two explicit type arguments, so the emitted term is an application rather than an atom. It was emitted as bare text, which is fine in assignment and `return` position but breaks at a call site, where juxtaposition binds tighter:

  return (Func_apply.func_apply (!var_x) Pulse.Lib.C.FuncPtr.null _ _);

parses as `func_apply` applied to four arguments with `null` unapplied, and F* rejects it with Error 189. PAL itself reported no diagnostic.

The neighbouring arms (`null`, `array_null`, `core_null`) are genuine atoms and need no parentheses; the function-pointer arm was written in the same style but is the only one that is an application. Use the `naryfn` helper at both sites, matching how the same term is already built for the `has_zero_default` instance.

Covered by new cases in test/func_pointer: NULL, bare 0 and an explicit cast in argument position, plus the via-a-local path that already worked. The callee does not call its callback, so no `is_valid` witness is needed and the proof stays trivial.