### PR TITLE
Post a diff of the generated F* output on pull requests

### DIFF
--- a/.github/scripts/pal-snapshot.sh
+++ b/.github/scripts/pal-snapshot.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Build `pal` inside a checkout of the repository, run the translation step of
+# the test suite, and copy the generated F* files into a snapshot directory.
+#
+# The snapshot directories produced by two different checkouts can then be
+# diffed against each other to see how a change affects the generated code.
+#
+# Usage: pal-snapshot.sh <worktree> <snapshot-dir>
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $0 <worktree> <snapshot-dir>" >&2
+  exit 2
+fi
+
+worktree=$(cd "$1" && pwd)
+mkdir -p "$2"
+snapshot=$(cd "$2" && pwd)
+
+cd "$worktree"
+
+# CI shares one CARGO_TARGET_DIR between the base and head checkouts so that
+# dependencies are compiled only once. Cargo decides freshness from file
+# modification times, and a freshly created worktree can look older than the
+# artifacts left behind by the previous snapshot, which would silently reuse
+# the wrong `pal` binary. Touching the tracked sources forces a rebuild of the
+# crate itself while leaving the dependency artifacts intact.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git ls-files -z | xargs -0 touch
+fi
+
+echo "::group::Building pal in $worktree"
+cargo build
+echo "::endgroup::"
+
+if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+  pal_bin="$CARGO_TARGET_DIR/debug/pal"
+else
+  pal_bin="$worktree/target/debug/pal"
+fi
+
+if [ ! -x "$pal_bin" ]; then
+  echo "error: pal binary not found at $pal_bin" >&2
+  exit 1
+fi
+
+echo "::group::Translating tests in $worktree"
+# Invoke `pal` directly rather than going through the test Makefiles: this
+# script has to work unchanged against older commits of the repository, whose
+# build rules may differ.
+#
+# Translation failures must not abort the snapshot: a diff that shows tests
+# going from "translated" to "failed to translate" is exactly the kind of
+# regression this report is meant to surface.
+find test -mindepth 1 -maxdepth 1 -type d \
+  ! -name '_*' ! -name '.*' -print0 |
+  PAL_BIN="$pal_bin" xargs -0 -P "$(nproc)" -I{} bash -c '
+    set -u
+    dir="$1"
+    cd "$dir" || exit 0
+    opts=()
+    [ -d include ] && opts+=(-I include)
+    "$PAL_BIN" "${opts[@]}" --outdir out *.c >/dev/null 2>&1 ||
+      echo "warning: pal failed in $dir" >&2
+  ' _ {}
+echo "::endgroup::"
+
+# Collect the generated F* sources and diagnostics. `source_range_info.json` is
+# deliberately skipped: it is machine-oriented data that changes with every
+# formatting tweak and would drown out the interesting parts of the diff.
+for dir in test/*/; do
+  name=$(basename "$dir")
+  outdir="$dir/out"
+  [ -d "$outdir" ] || continue
+
+  found=0
+  for file in "$outdir"/*.fst "$outdir"/*.fsti "$outdir"/diagnostics.json; do
+    [ -f "$file" ] || continue
+    if [ "$found" -eq 0 ]; then
+      mkdir -p "$snapshot/$name"
+      found=1
+    fi
+    # Absolute paths leak into diagnostics.json; strip the checkout prefix so
+    # that the base and head snapshots stay comparable.
+    sed "s|$worktree/||g" "$file" >"$snapshot/$name/$(basename "$file")"
+  done
+done
+
+echo "Snapshot written to $snapshot ($(find "$snapshot" -type f | wc -l) files)"

--- a/.github/workflows/pr-output-diff-command.yml
+++ b/.github/workflows/pr-output-diff-command.yml
@@ -1,0 +1,67 @@
+name: PR Output Diff Command
+
+# Lets a reviewer regenerate the generated-output diff on demand by commenting
+# `!diff` on a pull request. This re-runs the "PR Output Diff" workflow for the
+# pull request, which in turn refreshes the diff comment.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  pull-requests: write
+
+jobs:
+  rerun:
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '!diff')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge the command
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes >/dev/null
+
+      - name: Re-run the output diff workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          head_sha=$(gh pr view "$PR" -R "$REPO" --json headRefOid -q .headRefOid)
+          head_ref=$(gh pr view "$PR" -R "$REPO" --json headRefName -q .headRefName)
+          echo "pull request #$PR is at $head_sha ($head_ref)"
+
+          runs=$(gh run list -R "$REPO" \
+            --workflow "PR Output Diff" --event pull_request --limit 100 \
+            --json databaseId,headSha,headBranch,status)
+
+          # Prefer a run for the exact commit, and fall back to the most recent
+          # run for the pull request's branch.
+          run_id=$(echo "$runs" | jq -r \
+            --arg sha "$head_sha" --arg ref "$head_ref" \
+            '([.[] | select(.headSha == $sha)] + [.[] | select(.headBranch == $ref)])
+             | first | .databaseId // empty')
+
+          if [ -z "$run_id" ]; then
+            gh pr comment "$PR" -R "$REPO" --body \
+              "Sorry, I couldn't find a \`PR Output Diff\` run for \`$head_sha\` to re-run. Push a commit to the pull request to generate one."
+            exit 1
+          fi
+
+          status=$(gh run view "$run_id" -R "$REPO" --json status -q .status)
+          if [ "$status" != "completed" ]; then
+            gh pr comment "$PR" -R "$REPO" --body \
+              "A \`PR Output Diff\` run for this pull request is already $status; the diff comment will be updated when it finishes."
+            exit 0
+          fi
+
+          echo "re-running workflow run $run_id"
+          gh run rerun "$run_id" -R "$REPO"

--- a/.github/workflows/pr-output-diff-comment.yml
+++ b/.github/workflows/pr-output-diff-comment.yml
@@ -1,0 +1,119 @@
+name: PR Output Diff Comment
+
+# Posts the report produced by the "PR Output Diff" workflow as a comment on
+# the pull request. This runs from the default branch (never from pull request
+# code), which is what allows it to hold write permissions safely.
+
+on:
+  workflow_run:
+    workflows: ["PR Output Diff"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      # Publishing to a gist requires a token with the `gist` scope, which the
+      # built-in GITHUB_TOKEN does not have. If the secret is not configured we
+      # simply link to the workflow artifact instead.
+      HAS_GIST_TOKEN: ${{ secrets.PAL_GIST_TOKEN != '' }}
+    steps:
+      - name: Download report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download '${{ github.event.workflow_run.id }}' \
+            -R '${{ github.repository }}' \
+            -n pal-output-diff -D report
+
+      - name: Publish full diff as a gist
+        id: gist
+        if: env.HAS_GIST_TOKEN == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAL_GIST_TOKEN }}
+        run: |
+          if [ ! -s report/output.diff ]; then
+            echo "no diff to publish"
+            exit 0
+          fi
+          url=$(gh gist create report/output.diff \
+            --desc "pal generated output diff (run ${{ github.event.workflow_run.id }})")
+          echo "url=$url" >>"$GITHUB_OUTPUT"
+
+      - name: Post comment
+        uses: actions/github-script@v7
+        env:
+          GIST_URL: ${{ steps.gist.outputs.url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const fs = require('fs');
+
+            const MARKER = '<!-- pal-output-diff -->';
+            const MAX_COMMENT = 60000;
+            const MAX_STAT = 8000;
+
+            const meta = JSON.parse(fs.readFileSync('report/metadata.json', 'utf8'));
+            const diff = fs.readFileSync('report/output.diff', 'utf8');
+            let stat = fs.readFileSync('report/output.stat', 'utf8');
+
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${process.env.RUN_ID}`;
+            const gistUrl = process.env.GIST_URL;
+
+            let body = `${MARKER}\n### Generated F\\* output diff\n\n` +
+              `Effect of this pull request on the F\\* code \`pal\` generates for ` +
+              `the test suite (\`${meta.base_sha.slice(0, 7)}\` → ` +
+              `\`${meta.head_sha.slice(0, 7)}\`).\n\n`;
+
+            if (diff.trim() === '') {
+              body += '✅ The generated output is unchanged.\n';
+            } else {
+              if (stat.length > MAX_STAT) {
+                stat = stat.slice(0, MAX_STAT) + '\n... (summary truncated)\n';
+              }
+              body += `<details open>\n<summary>Summary</summary>\n\n` +
+                '```\n' + stat + '\n```\n\n</details>\n\n';
+
+              const links = [`[full diff artifact](${runUrl})`];
+              if (gistUrl) links.unshift(`[full diff gist](${gistUrl})`);
+              body += `Full diff: ${links.join(' · ')}\n\n`;
+
+              const budget = MAX_COMMENT - body.length - 200;
+              let shown = diff;
+              let truncated = false;
+              if (shown.length > budget) {
+                shown = shown.slice(0, budget);
+                // Avoid cutting in the middle of a line.
+                shown = shown.slice(0, shown.lastIndexOf('\n') + 1);
+                truncated = true;
+              }
+              body += `<details>\n<summary>Diff</summary>\n\n` +
+                '```diff\n' + shown + '\n```\n\n' +
+                (truncated ? '_Diff truncated; see the links above for the full version._\n' : '') +
+                '</details>\n';
+            }
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: meta.pr, per_page: 100 },
+            );
+            const existing = comments.find((c) => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: meta.pr, body,
+              });
+            }

--- a/.github/workflows/pr-output-diff.yml
+++ b/.github/workflows/pr-output-diff.yml
@@ -1,0 +1,92 @@
+name: PR Output Diff
+
+# Generates a diff of the F* code that `pal` produces for the test suite, as
+# of the base of the pull request versus as of its head. The diff is uploaded
+# as an artifact; the "PR Output Diff Comment" workflow picks it up and posts
+# it to the pull request.
+#
+# This workflow runs with untrusted pull request code and therefore has no
+# write permissions and no access to secrets.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-output-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Share a target directory between the base and head builds so that the
+  # dependencies are only compiled once.
+  CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out head
+        uses: actions/checkout@v4
+        with:
+          path: head
+          fetch-depth: 0
+
+      - name: Check out base
+        run: |
+          cd head
+          git fetch --no-tags origin '${{ github.event.pull_request.base.sha }}' || true
+          git worktree add --detach ../base '${{ github.event.pull_request.base.sha }}'
+
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+          sudo apt update
+          sudo apt install -y clang-20 libclang-cpp20-dev g++ clang-tools-20 libclang-20-dev
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ env.CARGO_TARGET_DIR }}
+          key: pr-output-diff-${{ runner.os }}-${{ hashFiles('head/Cargo.lock') }}
+          restore-keys: pr-output-diff-${{ runner.os }}-
+
+      - name: Snapshot base output
+        run: head/.github/scripts/pal-snapshot.sh base snapshots/base
+
+      - name: Snapshot head output
+        run: head/.github/scripts/pal-snapshot.sh head snapshots/head
+
+      - name: Compute diff
+        run: |
+          mkdir -p report
+          cd snapshots
+          git -c core.pager=cat diff --no-index --no-color --no-prefix \
+            -- base head >../report/output.diff || true
+          git -c core.pager=cat diff --no-index --no-color --no-prefix --stat=200,180 \
+            -- base head >../report/output.stat || true
+
+      - name: Record pull request metadata
+        run: |
+          cat >report/metadata.json <<EOF
+          {
+            "pr": ${{ github.event.pull_request.number }},
+            "base_sha": "${{ github.event.pull_request.base.sha }}",
+            "head_sha": "${{ github.event.pull_request.head.sha }}"
+          }
+          EOF
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pal-output-diff
+          path: report/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ pal [OPTIONS] <FILES>...
 
 ---
 
+## Reviewing pull requests
+
+Changes to the translator are easiest to judge by looking at the F\* code they
+produce. Every pull request therefore gets an automatic comment showing a diff
+of the output `pal` generates for the whole test suite, base versus head. The
+full diff is also attached to the workflow run as the `pal-output-diff`
+artifact.
+
+Comment `!diff` on a pull request to regenerate the report on demand.
+
+The workflows live in [`.github/workflows/`](.github/workflows):
+`pr-output-diff.yml` builds both revisions and computes the diff (via
+[`.github/scripts/pal-snapshot.sh`](.github/scripts/pal-snapshot.sh)),
+`pr-output-diff-comment.yml` posts it, and `pr-output-diff-command.yml`
+handles the `!diff` command. Configure a `PAL_GIST_TOKEN` repository secret
+(a token with the `gist` scope) to additionally publish each full diff as a
+gist; without it the comment links to the artifact instead.
+
+---
+
 ## Documentation
 
 Detailed references live in [`doc/`](doc/):


### PR DESCRIPTION
Reviewing PAL changes is hard when only the translator source is visible. Add a workflow that builds pal at the base and head of a pull request, runs the translation step over the whole test suite in both, and diffs the generated .fst/.fsti files and diagnostics.

The generating workflow runs untrusted PR code with read-only permissions and uploads the report as an artifact; a separate workflow_run workflow posts (and updates) a sticky comment, so it also works for pull requests from forks. Commenting !diff on a pull request re-runs the report on demand.