### PR TITLE
Make the !diff command work on existing pull requests

### DIFF
--- a/.github/workflows/pr-output-diff-command.yml
+++ b/.github/workflows/pr-output-diff-command.yml
@@ -1,8 +1,10 @@
 name: PR Output Diff Command
 
-# Lets a reviewer regenerate the generated-output diff on demand by commenting
-# `!diff` on a pull request. This re-runs the "PR Output Diff" workflow for the
-# pull request, which in turn refreshes the diff comment.
+# Lets a reviewer generate the generated-output diff on demand by commenting
+# `!diff` on a pull request. This dispatches the "PR Output Diff" workflow for
+# the pull request, which in turn refreshes the diff comment. Unlike re-running
+# an earlier run, dispatching also works for pull requests that have never had
+# a report generated for them.
 
 on:
   issue_comment:
@@ -13,55 +15,33 @@ permissions:
   pull-requests: write
 
 jobs:
-  rerun:
+  dispatch:
     if: >-
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '!diff')
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      COMMENT: ${{ github.event.comment.id }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Acknowledge the command
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api -X POST \
-            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+          gh api -X POST "repos/$REPO/issues/comments/$COMMENT/reactions" \
             -f content=eyes >/dev/null
 
-      - name: Re-run the output diff workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
+      - name: Dispatch the output diff workflow
+        run: gh workflow run pr-output-diff.yml -R "$REPO" -f pr="$PR"
+
+      - name: Confirm
         run: |
-          set -euo pipefail
+          gh api -X POST "repos/$REPO/issues/comments/$COMMENT/reactions" \
+            -f content=rocket >/dev/null
 
-          head_sha=$(gh pr view "$PR" -R "$REPO" --json headRefOid -q .headRefOid)
-          head_ref=$(gh pr view "$PR" -R "$REPO" --json headRefName -q .headRefName)
-          echo "pull request #$PR is at $head_sha ($head_ref)"
-
-          runs=$(gh run list -R "$REPO" \
-            --workflow "PR Output Diff" --event pull_request --limit 100 \
-            --json databaseId,headSha,headBranch,status)
-
-          # Prefer a run for the exact commit, and fall back to the most recent
-          # run for the pull request's branch.
-          run_id=$(echo "$runs" | jq -r \
-            --arg sha "$head_sha" --arg ref "$head_ref" \
-            '([.[] | select(.headSha == $sha)] + [.[] | select(.headBranch == $ref)])
-             | first | .databaseId // empty')
-
-          if [ -z "$run_id" ]; then
-            gh pr comment "$PR" -R "$REPO" --body \
-              "Sorry, I couldn't find a \`PR Output Diff\` run for \`$head_sha\` to re-run. Push a commit to the pull request to generate one."
-            exit 1
-          fi
-
-          status=$(gh run view "$run_id" -R "$REPO" --json status -q .status)
-          if [ "$status" != "completed" ]; then
-            gh pr comment "$PR" -R "$REPO" --body \
-              "A \`PR Output Diff\` run for this pull request is already $status; the diff comment will be updated when it finishes."
-            exit 0
-          fi
-
-          echo "re-running workflow run $run_id"
-          gh run rerun "$run_id" -R "$REPO"
+      - name: Report failure
+        if: failure()
+        run: |
+          gh pr comment "$PR" -R "$REPO" --body \
+            "Sorry, I couldn't start the \`PR Output Diff\` workflow. See [the logs]($RUN_URL) for details."

--- a/.github/workflows/pr-output-diff.yml
+++ b/.github/workflows/pr-output-diff.yml
@@ -5,18 +5,25 @@ name: PR Output Diff
 # as an artifact; the "PR Output Diff Comment" workflow picks it up and posts
 # it to the pull request.
 #
-# This workflow runs with untrusted pull request code and therefore has no
-# write permissions and no access to secrets.
+# The job builds and runs code from the pull request, so it deliberately holds
+# no write permissions and uses no secrets beyond a read-only GITHUB_TOKEN.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to report on"
+        required: true
+        type: string
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: pr-output-diff-${{ github.event.pull_request.number }}
+  group: pr-output-diff-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 env:
@@ -24,22 +31,64 @@ env:
   # Share a target directory between the base and head builds so that the
   # dependencies are only compiled once.
   CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
+  PR: ${{ github.event.pull_request.number || inputs.pr }}
+  REPO: ${{ github.repository }}
 
 jobs:
   diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out head
+      # Checked out at the merge commit for `pull_request` events and at the
+      # default branch for `workflow_dispatch`. Either way it provides the
+      # snapshot script, which is deliberately taken from here rather than
+      # from the pull request head: pull requests opened before this workflow
+      # existed do not contain it.
+      - name: Check out repository
         uses: actions/checkout@v4
         with:
-          path: head
+          path: repo
           fetch-depth: 0
 
-      - name: Check out base
+      - name: Resolve the revisions to compare
+        id: revs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd head
-          git fetch --no-tags origin '${{ github.event.pull_request.base.sha }}' || true
-          git worktree add --detach ../base '${{ github.event.pull_request.base.sha }}'
+          set -euo pipefail
+          case "$PR" in
+            '' | *[!0-9]*)
+              echo "error: invalid pull request number '$PR'" >&2
+              exit 1
+              ;;
+          esac
+
+          pr_json=$(gh api "repos/$REPO/pulls/$PR")
+          base_branch=$(jq -r .base.ref <<<"$pr_json")
+          head_sha=$(jq -r .head.sha <<<"$pr_json")
+
+          cd repo
+          # `refs/pull/N/merge` exists in this repository even for pull
+          # requests from forks, and comparing against its first parent shows
+          # exactly the effect of merging the pull request.
+          if git fetch --no-tags --force origin "refs/pull/$PR/merge:refs/pal/merge"; then
+            head=$(git rev-parse refs/pal/merge)
+            base=$(git rev-parse 'refs/pal/merge^1')
+          else
+            echo "no merge ref (the pull request probably conflicts); comparing against the merge base"
+            git fetch --no-tags --force origin "refs/pull/$PR/head:refs/pal/head"
+            git fetch --no-tags --force origin "$base_branch:refs/pal/base"
+            head=$(git rev-parse refs/pal/head)
+            base=$(git merge-base refs/pal/base refs/pal/head)
+          fi
+          echo "comparing $base -> $head (pull request #$PR, head $head_sha)"
+
+          git worktree add --detach ../base "$base"
+          git worktree add --detach ../head "$head"
+
+          {
+            echo "base=$base"
+            echo "head_sha=$head_sha"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Install clang
         run: |
@@ -60,10 +109,10 @@ jobs:
           restore-keys: pr-output-diff-${{ runner.os }}-
 
       - name: Snapshot base output
-        run: head/.github/scripts/pal-snapshot.sh base snapshots/base
+        run: repo/.github/scripts/pal-snapshot.sh base snapshots/base
 
       - name: Snapshot head output
-        run: head/.github/scripts/pal-snapshot.sh head snapshots/head
+        run: repo/.github/scripts/pal-snapshot.sh head snapshots/head
 
       - name: Compute diff
         run: |
@@ -75,14 +124,12 @@ jobs:
             -- base head >../report/output.stat || true
 
       - name: Record pull request metadata
+        env:
+          BASE_SHA: ${{ steps.revs.outputs.base }}
+          HEAD_SHA: ${{ steps.revs.outputs.head_sha }}
         run: |
-          cat >report/metadata.json <<EOF
-          {
-            "pr": ${{ github.event.pull_request.number }},
-            "base_sha": "${{ github.event.pull_request.base.sha }}",
-            "head_sha": "${{ github.event.pull_request.head.sha }}"
-          }
-          EOF
+          jq -n --argjson pr "$PR" --arg base "$BASE_SHA" --arg head "$HEAD_SHA" \
+            '{pr: $pr, base_sha: $base, head_sha: $head}' >report/metadata.json
 
       - name: Upload report
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ of the output `pal` generates for the whole test suite, base versus head. The
 full diff is also attached to the workflow run as the `pal-output-diff`
 artifact.
 
-Comment `!diff` on a pull request to regenerate the report on demand.
+Comment `!diff` on a pull request to regenerate the report on demand; the
+"PR Output Diff" workflow can also be started manually from the Actions tab
+for any pull request number.
 
 The workflows live in [`.github/workflows/`](.github/workflows):
 `pr-output-diff.yml` builds both revisions and computes the diff (via


### PR DESCRIPTION
Re-running the last "PR Output Diff" run only works if one exists, which is never the case for pull requests opened before the workflow was added. Give the workflow a workflow_dispatch trigger taking a pull request number and have the !diff command dispatch it instead.

The revisions to compare are now derived from refs/pull/N/merge (falling back to the merge base when the pull request conflicts), and the snapshot script is taken from the checkout of this workflow's own revision rather than from the pull request head, which need not contain it.