### PR TITLE
Comment on the pull request for !diff-requested reports too

### DIFF
--- a/.github/workflows/pr-output-diff-command.yml
+++ b/.github/workflows/pr-output-diff-command.yml
@@ -1,10 +1,12 @@
 name: PR Output Diff Command
 
 # Lets a reviewer generate the generated-output diff on demand by commenting
-# `!diff` on a pull request. This dispatches the "PR Output Diff" workflow for
-# the pull request, which in turn refreshes the diff comment. Unlike re-running
-# an earlier run, dispatching also works for pull requests that have never had
-# a report generated for them.
+# `!diff` on a pull request.
+#
+# The report is produced by dispatching the "PR Output Diff" workflow. GitHub
+# does not emit `workflow_run` events for runs started with the GITHUB_TOKEN,
+# so this workflow waits for the dispatched run itself and then calls the
+# comment workflow directly rather than relying on that trigger.
 
 on:
   issue_comment:
@@ -12,6 +14,7 @@ on:
 
 permissions:
   actions: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -20,11 +23,15 @@ jobs:
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '!diff')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      run_id: ${{ steps.run.outputs.run_id }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR: ${{ github.event.issue.number }}
       REPO: ${{ github.repository }}
       COMMENT: ${{ github.event.comment.id }}
+      SERVER: ${{ github.server_url }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Acknowledge the command
@@ -33,7 +40,48 @@ jobs:
             -f content=eyes >/dev/null
 
       - name: Dispatch the output diff workflow
-        run: gh workflow run pr-output-diff.yml -R "$REPO" -f pr="$PR"
+        id: run
+        run: |
+          set -euo pipefail
+
+          # Run ids increase monotonically, so the run we are about to create
+          # is the first one newer than the latest existing run.
+          before=$(gh run list -R "$REPO" --workflow pr-output-diff.yml \
+            --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+          gh workflow run pr-output-diff.yml -R "$REPO" -f pr="$PR"
+
+          # `gh workflow run` does not report the run it created, so look it up
+          # by the run name that the dispatched workflow sets.
+          title="Output diff for pull request #$PR"
+          run_id=""
+          for _ in $(seq 1 40); do
+            sleep 5
+            run_id=$(gh run list -R "$REPO" --workflow pr-output-diff.yml \
+              --event workflow_dispatch --limit 20 \
+              --json databaseId,displayTitle \
+              --jq "[.[] | select(.displayTitle == \"$title\" and .databaseId > $before)]
+                    | first | .databaseId // empty")
+            [ -n "$run_id" ] && break
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "error: the dispatched run never showed up" >&2
+            exit 1
+          fi
+
+          echo "waiting for $SERVER/$REPO/actions/runs/$run_id"
+          gh run watch "$run_id" -R "$REPO" --interval 20 >/dev/null || true
+
+          conclusion=$(gh run view "$run_id" -R "$REPO" --json conclusion --jq .conclusion)
+          echo "run $run_id finished: $conclusion"
+          if [ "$conclusion" != "success" ]; then
+            echo "reported=true" >>"$GITHUB_OUTPUT"
+            gh pr comment "$PR" -R "$REPO" --body \
+              "The [\`PR Output Diff\` run]($SERVER/$REPO/actions/runs/$run_id) $conclusion, so there is no diff to report."
+            exit 1
+          fi
+
+          echo "run_id=$run_id" >>"$GITHUB_OUTPUT"
 
       - name: Confirm
         run: |
@@ -41,7 +89,19 @@ jobs:
             -f content=rocket >/dev/null
 
       - name: Report failure
-        if: failure()
+        if: failure() && steps.run.outputs.reported != 'true'
         run: |
           gh pr comment "$PR" -R "$REPO" --body \
-            "Sorry, I couldn't start the \`PR Output Diff\` workflow. See [the logs]($RUN_URL) for details."
+            "Sorry, I couldn't run the \`PR Output Diff\` workflow. See [the logs]($RUN_URL) for details."
+
+  comment:
+    needs: dispatch
+    if: needs.dispatch.outputs.run_id != ''
+    uses: ./.github/workflows/pr-output-diff-comment.yml
+    with:
+      run_id: ${{ needs.dispatch.outputs.run_id }}
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/pr-output-diff-comment.yml
+++ b/.github/workflows/pr-output-diff-comment.yml
@@ -3,11 +3,22 @@ name: PR Output Diff Comment
 # Posts the report produced by the "PR Output Diff" workflow as a comment on
 # the pull request. This runs from the default branch (never from pull request
 # code), which is what allows it to hold write permissions safely.
+#
+# GitHub suppresses `workflow_run` events for runs that were started with the
+# GITHUB_TOKEN, so reports requested through the `!diff` command never reach
+# the trigger below. The "PR Output Diff Command" workflow therefore calls this
+# workflow directly instead.
 
 on:
   workflow_run:
     workflows: ["PR Output Diff"]
     types: [completed]
+  workflow_call:
+    inputs:
+      run_id:
+        description: "The PR Output Diff run holding the report to post"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,19 +27,20 @@ permissions:
 
 jobs:
   comment:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: inputs.run_id != '' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       # Publishing to a gist requires a token with the `gist` scope, which the
       # built-in GITHUB_TOKEN does not have. If the secret is not configured we
       # simply link to the workflow artifact instead.
       HAS_GIST_TOKEN: ${{ secrets.PAL_GIST_TOKEN != '' }}
+      RUN_ID: ${{ inputs.run_id || github.event.workflow_run.id }}
     steps:
       - name: Download report
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run download '${{ github.event.workflow_run.id }}' \
+          gh run download "$RUN_ID" \
             -R '${{ github.repository }}' \
             -n pal-output-diff -D report
 
@@ -43,14 +55,13 @@ jobs:
             exit 0
           fi
           url=$(gh gist create report/output.diff \
-            --desc "pal generated output diff (run ${{ github.event.workflow_run.id }})")
+            --desc "pal generated output diff (run $RUN_ID)")
           echo "url=$url" >>"$GITHUB_OUTPUT"
 
       - name: Post comment
         uses: actions/github-script@v7
         env:
           GIST_URL: ${{ steps.gist.outputs.url }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr-output-diff.yml
+++ b/.github/workflows/pr-output-diff.yml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+# Also used by the `!diff` command to find the run it just dispatched.
+run-name: "Output diff for pull request #${{ github.event.pull_request.number || inputs.pr }}"
+
 permissions:
   contents: read
   pull-requests: read

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ artifact.
 
 Comment `!diff` on a pull request to regenerate the report on demand; the
 "PR Output Diff" workflow can also be started manually from the Actions tab
-for any pull request number.
+for any pull request number. On-demand reports take a few minutes, since the
+command waits for the run it started before posting.
 
 The workflows live in [`.github/workflows/`](.github/workflows):
 `pr-output-diff.yml` builds both revisions and computes the diff (via


### PR DESCRIPTION
GitHub does not emit workflow_run events for runs started with the GITHUB_TOKEN, so the run dispatched by the !diff command completed without ever triggering the comment workflow.

Make the comment workflow callable (workflow_call) in addition to its workflow_run trigger, and have the command workflow wait for the run it dispatched and then call it directly. The dispatched run is identified by the run name now set by the diff workflow.