### PR TITLE
Bump F* nightly to 2026-08-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ it passes, the implementation satisfies the spec. More availabe at [`examples/`]
 | LLVM dev headers | 20.x | `llvm-config`, `libclang-cpp20-dev`, `libclang-20-dev` |
 | g++ | recent | builds the C++ FFI ([`cpp/impl.cpp`](cpp/impl.cpp)) |
 | Rust | 2024 edition | compiles the PAL binary |
-| F\*/Pulse | nightly 2026-08-24 | verifies generated `.fst` output |
+| F\*/Pulse | nightly 2026-08-26 | verifies generated `.fst` output |
 
 ### Setup (Ubuntu / Debian)
 

--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-24 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-26 "$@"

--- a/pulse/Pulse.Lib.C.Ref.fsti
+++ b/pulse/Pulse.Lib.C.Ref.fsti
@@ -102,9 +102,7 @@ ensures r |->? Frac p (Some x)
   introduce exists* v. (r |-> Frac p v) ** pure (Some x == Some v)
   with x;
   rewrite (exists* (v:a). (r |-> Frac p v) ** pure (Some x == Some v)) as (maybe_pts_to r #p (Some x));
-  rewrite (maybe_pts_to r #p (Some x)) as (maybe_pts_to r #(1.0R *. p) (Some x));
-  fold (pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) (Some x);
-  rewrite ((pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) (Some x)) as (r |->? Frac p (Some x));
+  rewrite (maybe_pts_to r #p (Some x)) as (r |->? Frac p (Some x));
 }
 
 ghost
@@ -113,9 +111,7 @@ requires pure (is_null r)
 ensures r |->? Frac p None
 {
   rewrite (pure (None #a == None #a)) as (maybe_pts_to r #p None);
-  rewrite (maybe_pts_to r #p None) as (maybe_pts_to r #(1.0R *. p) None);
-  fold (pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) None;
-  rewrite ((pts_to_nullable_pts_to a).pts_to_nullable r #(1.0R *. p) None) as (r |->? Frac p None);
+  rewrite (maybe_pts_to r #p None) as (r |->? Frac p None);
 }
 
 


### PR DESCRIPTION
Also revert the `intro_non_null` / `intro_null` workaround added in the 2026-08-24 bump. FStarLang/FStar#4472 (the fold-direction `rewrite` not reducing the `pulse_unfold` instance projection) was fixed upstream by FStarLang/FStar#4473, so the plain single-step rewrites verify again.