### PR TITLE
Bump F*/Pulse nightly to 2026-08-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ it passes, the implementation satisfies the spec. More availabe at [`examples/`]
 | LLVM dev headers | 20.x | `llvm-config`, `libclang-cpp20-dev`, `libclang-20-dev` |
 | g++ | recent | builds the C++ FFI ([`cpp/impl.cpp`](cpp/impl.cpp)) |
 | Rust | 2024 edition | compiles the PAL binary |
-| F\*/Pulse | nightly 2026-08-24 | verifies generated `.fst` output |
+| F\*/Pulse | nightly 2026-08-27 | verifies generated `.fst` output |
 
 ### Setup (Ubuntu / Debian)
 

--- a/opt/install-fstar.sh
+++ b/opt/install-fstar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-24 "$@"
+curl -fsSL https://aka.ms/install-fstar | bash -s -- --nightly --version 2026-08-27 "$@"


### PR DESCRIPTION
(TO BE MERGED ON 26/8/26)
Update the pinned nightly in opt/install-fstar.sh and the toolchain table in README.md.
This should include https://github.com/FStarLang/FStar/pull/4492