### PR TITLE
test/nullable: exercise passing NULL to _nullable parameters

### DIFF
--- a/test/nullable/nullable.c
+++ b/test/nullable/nullable.c
@@ -1,4 +1,5 @@
 #include "pal.h"
+#include <stddef.h>
 #include <stdint.h>
 
 // A nullable array parameter: the pts_to is wrapped in unless_null, so passing
@@ -22,3 +23,55 @@ _include_pulse(Nullable_include1,
 // unless_null.
 void takes_nullable_refined(
     _nullable _refine(_inline_pulse(Nullable_include1.nonneg_offset $(this))) _arrayptr int *p) {}
+
+// A nullable pointer to a struct.
+struct ops { int32_t a; };
+void takes_nullable_struct(_nullable const struct ops *p) {}
+
+// A nullable function pointer.
+typedef int (*binop)(int, int);
+void takes_nullable_fnptr(_nullable binop f) {}
+
+// Passing NULL to a _nullable parameter needs two ghost steps: the precondition
+// is `unless_null p (...)`, and Pulse cannot introduce it on its own because
+// `has_is_null` is still a uvar at match time. Naming the pointer type fixes it.
+//
+// Both arguments of the intro must be explicit, and the trailing elim is needed
+// to release what the callee hands back. `p` is the callee's precondition as
+// printed in the generated .fsti, minus any [@@pulse_eager_unfold] predicate
+// that reduces to emp (writing those out breaks the match).
+
+void call_ref(void) {
+    _ghost_stmt(Pulse.Lib.C.Nullable.intro_unless_null_null (null #Int32.t) (Pulse.Lib.Reference.pts_to (null #Int32.t) #1.0R 0l));
+    takes_nullable_ref(NULL);
+    _ghost_stmt(Pulse.Lib.C.Nullable.elim_unless_null_null (null #Int32.t) _);
+}
+// _array needs array_pts_to_full and a concrete full_array_spec.
+void call_array(void) {
+    _ghost_stmt(Pulse.Lib.C.Nullable.intro_unless_null_null (array_null #Int32.t) (array_pts_to_full (array_null #Int32.t) 1.0R (array_spec_zeroed Int32.t 0 0l)));
+    takes_nullable_array(NULL);
+    _ghost_stmt(Pulse.Lib.C.Nullable.elim_unless_null_null (array_null #Int32.t) _);
+}
+// _arrayptr emits no pts_to of its own, so p is emp.
+void call_arrayptr(void) {
+    _ghost_stmt(Pulse.Lib.C.Nullable.intro_unless_null_null (array_null #Int32.t) emp);
+    takes_nullable_arrayptr(NULL);
+    _ghost_stmt(Pulse.Lib.C.Nullable.elim_unless_null_null (array_null #Int32.t) _);
+}
+// A refinement rides inside the same unless_null, so p is the refinement.
+void call_refined(void) {
+    _ghost_stmt(Pulse.Lib.C.Nullable.intro_unless_null_null (array_null #Int32.t) (Nullable_include1.nonneg_offset (array_null #Int32.t)));
+    takes_nullable_refined(NULL);
+    _ghost_stmt(Pulse.Lib.C.Nullable.elim_unless_null_null (array_null #Int32.t) _);
+}
+void call_struct(void) {
+    _ghost_stmt(Pulse.Lib.C.Nullable.intro_unless_null_null (null #Struct_ops.struct_ops) (Pulse.Lib.Reference.pts_to (null #Struct_ops.struct_ops) #1.0R (Struct_ops.Mkstruct_ops 0l)));
+    takes_nullable_struct(NULL);
+    _ghost_stmt(Pulse.Lib.C.Nullable.elim_unless_null_null (null #Struct_ops.struct_ops) _);
+}
+// A function pointer uses FuncPtr.null, and its pred is emp.
+void call_fnptr(void) {
+    _ghost_stmt(Pulse.Lib.C.Nullable.intro_unless_null_null (Pulse.Lib.C.FuncPtr.null (Int32.t & Int32.t) Int32.t) emp);
+    takes_nullable_fnptr(NULL);
+    _ghost_stmt(Pulse.Lib.C.Nullable.elim_unless_null_null (Pulse.Lib.C.FuncPtr.null (Int32.t & Int32.t) Int32.t) _);
+}


### PR DESCRIPTION
TLDR: Add tests on how to call a function and passing NULL to a nullable arguments. 

nullable.c only declared _nullable parameters; nothing called them with NULL, and null_support.c passes NULL only to _plain parameters. So the _nullable + NULL-argument combination was untested.

Add call sites for each parameter kind (reference, array, arrayptr, refined arrayptr, struct pointer, function pointer), along with the two declarations needed for the latter two.

Each call is bracketed by intro_unless_null_null / elim_unless_null_null ghost steps. These are required because unless_null is a plain let, so it does not collapse to emp on its own, and Pulse cannot apply its own [@@pulse_intro] rule while the has_is_null instance argument is still an unsolved uvar. Naming the pointer type explicitly resolves it.