### PR TITLE
Prove two admits and fix an unsound spec in Pulse.Lib.C.Array

### DIFF
--- a/pulse/Pulse.Lib.C.Array.fst
+++ b/pulse/Pulse.Lib.C.Array.fst
@@ -27,6 +27,10 @@ let array_spec_initd #a (s: array_spec a) (i: nat) : prop = i < Seq.length s /\ 
 let array_spec_mask #a (s: array_spec a) (i: nat) : prop = i < Seq.length s /\ ~(OutOfMask? (Seq.index s i))
 let array_spec_idx #a (s: array_spec a) (i: nat { array_spec_initd s i }) : Tot a = let Val x = Seq.index s i in x
 
+// Deliberately unspecified: there is no postcondition, so `null` would
+// discharge this admit while turning an honest gap into a silent extraction
+// bug. The real fix is to give it a spec (an immutable pts_to at the literal's
+// contents), which is a design change, not a proof.
 let array_literal_to_ref #a #n (_: full_array_lspec a n) : Tot (R.ref a) =
   admit ()
 
@@ -74,12 +78,15 @@ let array_spec_zeroed_idx a n x i = ()
 let array_pts_to #a (x: array a) (p: perm) (y: array_spec a) : slprop =
   A.pts_to_mask x #p (to_seq y) (to_mask y)
 
-fn array_read_all u#a (#a: Type u#a) (x: array a)
-  preserves array_pts_to x 'p 'y
+// Ghost, not concrete: an array_spec records Uninit/OutOfMask cells, which no
+// C program can read. The 'p/'y sugar binds erased implicits, so a concrete fn
+// could not return y either.
+ghost fn array_read_all u#a (#a: Type u#a) (x: array a) (#p: perm) (#y: array_spec a)
+  preserves array_pts_to x p y
   returns z: array_spec a
-  ensures rewrites_to z 'y
+  ensures rewrites_to z y
 {
-  admit ()
+  y
 }
 
 ghost fn intro_array_pts_to_uninit' u#a (#t: Type u#a)
@@ -239,17 +246,29 @@ fn stack_free_array u#a (#a:Type u#a) (r:array a)
   free_array r;
 }
 
-fn stack_alloc_array_full u#a (#a: Type u#a) {| small_type u#a |} (s: full_array_spec a)
+// The SZ.fits refinement is required for soundness, not just convenience.
+// Without it the spec is unsatisfiable: array_spec_zeroed builds a
+// full_array_spec of arbitrary length, so this would promise to allocate an
+// array of, say, 2^70 elements. Since Pulse.Lib.Array.Core.length carries
+// `ensures SZ.fits`, admitting that promise lets a caller derive SZ.fits n for
+// any n, and hence build a size_t too large for any machine word.
+// It is also the premise a real implementation needs: allocating requires an
+// SZ.t length, which cannot be built from array_spec_len s without it.
+fn stack_alloc_array_full u#a (#a: Type u#a) {| small_type u#a |}
+  (s: full_array_spec a { SZ.fits (array_spec_len s) })
   returns r : array a
   ensures array_pts_to_full r 1.0R s
 {
+  // Still admitted: a full proof additionally needs a loop to fill the array
+  // with s's contents.
   admit ()
 }
 
 fn stack_free_array_full u#a (#a: Type u#a) (r: array a) (#s: erased (full_array_spec a))
   requires array_pts_to_full r 1.0R s
 {
-  admit ()
+  intro_array_pts_to_uninit' r;
+  stack_free_array r;
 }
 
 fn calloc_array u#a (#a:Type u#a) {| small_type u#a |} {| has_zero_default a |} (sz:SZ.t)
@@ -575,9 +594,9 @@ fn arrayptr_read u#a (#t: Type u#a) (x: array t) (i: SZ.t)
   ensures rewrites_to res (array_spec_idx s (arrayptr_off x y + SZ.v i))
 {
   admit ()
-  // Stuck: need to compute the actual index into y's backing array
-  // from the arrayptr offset, unfold array_pts_to, and call mask_read
-  // at the computed index. Requires showing SZ.fits for the index.
+  // Stuck: permission is held on the backing array y, but the runtime handle
+  // is x, and the connecting offset `arrayptr_off x y` is GTot. So there is no
+  // runtime index to pass to mask_read.
 }
 
 fn arrayptr_write u#a (#t: Type u#a) (x: array t) (i: SZ.t) (v: t)
@@ -590,8 +609,8 @@ fn arrayptr_write u#a (#t: Type u#a) (x: array t) (i: SZ.t) (v: t)
     pure (s' == array_spec_upd s (arrayptr_off x y + SZ.v i) v)
 {
   admit ()
-  // Stuck: same issue as arrayptr_read — need to compute index,
-  // unfold, call mask_write, then refold with updated spec.
+  // Stuck: same issue as arrayptr_read — `arrayptr_off x y` is GTot, so there
+  // is no runtime index to pass to mask_write.
 }
 
 fn arrayptr_assign_ret u#a (#t: Type u#a) (x: array t) (i: SZ.t) (v: t)

--- a/pulse/Pulse.Lib.C.Array.fsti
+++ b/pulse/Pulse.Lib.C.Array.fsti
@@ -80,10 +80,12 @@ let array_spec_get #a (s: array_spec a) (i: nat) : GTot (option a) =
 let array_spec_of #a (x: array a) #p #y =
   observe (array_pts_to x p) #y
 
-fn array_read_all u#a (#a: Type u#a) (x: array a)
-  preserves array_pts_to x 'p 'y
+// Ghost, not concrete: an array_spec records Uninit/OutOfMask cells, which no
+// C program can read.
+ghost fn array_read_all u#a (#a: Type u#a) (x: array a) (#p: perm) (#y: array_spec a)
+  preserves array_pts_to x p y
   returns z: array_spec a
-  ensures rewrites_to z 'y
+  ensures rewrites_to z y
 
 ghost fn array_value_of u#a (#a: Type u#a) (x: array a) (#p: perm) (#y: array_spec a)
   preserves array_pts_to x p y
@@ -209,7 +211,12 @@ fn stack_alloc_array u#a (#a:Type u#a) {| small_type u#a |} (sz:SZ.t)
 fn stack_free_array u#a (#a:Type u#a) (r:array a)
   requires array_pts_to_uninit' r
 
-fn stack_alloc_array_full u#a (#a: Type u#a) {| small_type u#a |} (s: full_array_spec a)
+// The SZ.fits refinement is required for soundness: without it the spec is
+// unsatisfiable (array_spec_zeroed builds a full_array_spec of arbitrary
+// length), and since Array.Core.length carries `ensures SZ.fits`, admitting it
+// would let a caller derive SZ.fits n for any n. See the .fst for detail.
+fn stack_alloc_array_full u#a (#a: Type u#a) {| small_type u#a |}
+  (s: full_array_spec a { SZ.fits (array_spec_len s) })
   returns r : array a
   ensures array_pts_to_full r 1.0R s
 


### PR DESCRIPTION
`Pulse.Lib.C.Array.fst` is the only file under `pulse/` with any admits — 14 of them, plus 2 `assume`s. This audits all of them and addresses three. **Admits 14 → 12, plus one unsoundness closed.**

### 1. `stack_alloc_array_full` was unsound

Its signature is a promise: *"hand me any array contents `s`, and I'll hand you back a stack array holding exactly those contents."*

Nothing bounded `s`. `array_spec_zeroed a n x` builds a valid `full_array_spec` for **any** `n`, so the signature promised to allocate an array of e.g. 2^70 elements — something no implementation can do. Normally F* would reject an impossible spec, but the body is `admit ()`, so it was accepted and available for reasoning.

The damage: `Pulse.Lib.Array.Core.length` is `Ghost nat (ensures SZ.fits)`, i.e. *every* array's length fits in a `size_t`. Chaining the false promise with that fact yields `SZ.fits n` for a freely chosen `n`. This is not theoretical — the following probe **verified with 0 errors**:

```fstar
fn make_impossible_sizet ()
  requires emp
  returns z: SZ.t
  ensures pure (SZ.v z == pow2 70)
```

That is verified code producing a C `size_t` holding 2^70, which no machine word can represent. To be precise: F* cannot derive `False` here, because `SZ.fits` is abstract with no upper-bound axiom. The logic stays consistent; what breaks is the **C machine model**.

**Fix:** refine the argument to `{ SZ.fits (array_spec_len s) }`. The probe is now rejected exactly where intended:

```
* Error 19: Failed to prove:
    FStar.SizeT.fits (array_spec_len (huge (pow2 70)))
```

This is not a guard bolted on to block the probe — it is the premise a real implementation needs anyway, since allocating requires an `SZ.t` length that cannot be built from `array_spec_len s` without it. Its absence is precisely *why* the function was unprovable. The `admit ()` remains, but now asserts something true; a full proof additionally needs a fill loop.

**No PAL change required.** Emitted call sites use `array_spec_of_list_with_len xs n` with literal `n`, carrying `array_spec_len s == n`; `fits_at_least_16` discharges it by SMTPat.

### 2. `array_read_all` — an erasure violation, now provable

It was a concrete `fn` returning an `array_spec`. Two problems: `array_spec` records `Uninit`/`OutOfMask` cells, which no C program can read (nor can it observe where its own permission ends); and the `'p`/`'y` sugar binds **erased** implicits, so the body could not return `y` either — it failed with *"`FStar.Ghost.erased … perm` is not a subtype of `r: real{r >. 0.0R}`"*. The signature asked a runtime function to produce ghost data.

Now a `ghost fn` with explicit `(#p: perm) (#y: array_spec a)`, body `y` — matching its immediate neighbour `array_value_of`, which already uses exactly this shape. Safe despite being a public signature change: it has **zero** occurrences across all `test/*/out/`, and `emit.rs:255` already noted "currently no emit site does".

### 3. `stack_free_array_full` — proved directly

`array_pts_to_full` unfolds to `array_pts_to`, and `array_spec_full s` entails `array_spec_full_mask s`, which is exactly what `intro_array_pts_to_uninit'` wants. The explicit `intro_` line is kept so the proof doesn't rely on unfolding heuristics.

### Comment corrections

- `arrayptr_read`/`write` blamed *"requires showing `SZ.fits`"*. That is wrong and misleading: the blocker is that permission is held on the backing array `y` while the runtime handle is `x`, and the connecting `arrayptr_off x y` is `GTot` — there is no runtime index at *any* `fits` assumption.
- `array_literal_to_ref` now records that it is **deliberately** unspecified. It has no postcondition, so `null` would discharge the admit — but that converts an honest gap into a silent extraction bug. `test/stringlit/out/Func_get_name.fsti` shows the real issue: no `ensures`, hence no `pts_to`, so PAL returns string literals a caller can never read. The fix is a proper spec, which is design work.

### What is *not* changed, and why

The remaining 12 admits are genuine primitives, correctly specified. `arrayptr_eq` is representative: the natural proof type-checks but SMT fails on the **backward** direction, because `array` is abstract with three observables (`base_of`, `offset_of`, `length`) and nothing forces base+offset to determine an array. In C an address *is* base+offset; `length` is a ghost artifact. The spec is right and simply isn't derivable from a primitive that distinguishes handles more finely than C distinguishes addresses. Same for `arrayptr_diff`/`lt`/`lte`, the shifts, `array_to_arrayptr`, and `arrayptr_borrow_cell`.

The two `assume`s also stand: the one at `:207` needs an upstream strengthening (`mask_alloc` guarantees length only, not all-`None`), and the `freeable_array` one models a stack/heap distinction that doesn't exist yet.

### Caveats

The unsoundness was **not reachable from outside the module** today — the probe needs `A.pts_to_mask_len`, and the C-level `length` is `GTot nat` re-exporting no `fits`. Tellingly, `Array.fsti:28` carries a **commented-out** `array_spec_len_fits` lemma; that comment is load-bearing, and uncommenting it — an obvious convenience — would expose the hole to all callers. PAL itself never triggered it. So this was latent and contained by two accidents, which is exactly why it is worth closing now rather than later.

### Testing

`make -C pulse -j$(nproc)` and full `make test -j16 -k` both exit 0 with **0 errors**.