### PR TITLE
Fix macOS portability

### DIFF
--- a/cpp/impl.cpp
+++ b/cpp/impl.cpp
@@ -3245,8 +3245,11 @@ static void parse_file(RefMut<Ctx> ctx) {
 
   // Tool.appendArgumentsAdjuster(OptionsParser->getArgumentsAdjuster());
 
+  // On macOS, _FORTIFY_SOURCE is set to 2 by default, hence all libc functions
+  // will be rewritten into calls the translator does not model.
   Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
-      {"-DC2PULSE", "-fno-builtin"}, ArgumentInsertPosition::BEGIN));
+      {"-DC2PULSE", "-fno-builtin", "-D_FORTIFY_SOURCE=0"},
+      ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
       {"-resource-dir", getResourcesPath()}, ArgumentInsertPosition::BEGIN));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,32 @@ struct Cli {
     files: Vec<String>,
 }
 
+/// On macOS, system headers live in an SDK. Looking up the SDK path using
+/// `xcrun` and setting SDKROOT.
+#[cfg(target_os = "macos")]
+fn set_default_sdkroot() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    if std::env::var_os("SDKROOT").is_some() {
+        return;
+    }
+    let Ok(out) = std::process::Command::new("xcrun")
+        .args(["--sdk", "macosx", "--show-sdk-path"])
+        .output()
+    else {
+        return;
+    };
+    if !out.status.success() {
+        return;
+    }
+    let path = OsStr::from_bytes(out.stdout.trim_ascii());
+    if !path.is_empty() {
+        // SAFETY: called at the top of main, before any threads exist.
+        unsafe { std::env::set_var("SDKROOT", path) };
+    }
+}
+
 /// Write `contents` to `path` only if the file doesn't already exist with
 /// identical contents. This avoids bumping the timestamp and triggering
 /// unnecessary F* reverification.
@@ -96,6 +122,9 @@ fn serialize_diags(diags: &Diagnostics) -> String {
 }
 
 fn main() {
+    #[cfg(target_os = "macos")]
+    set_default_sdkroot();
+
     let cli = Cli::parse();
 
     if cli.files.is_empty() {

--- a/test/check-template.sh
+++ b/test/check-template.sh
@@ -6,19 +6,20 @@ set -u
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-declare -A EXPECTED=(
-  [Makefile]="../_templates/Makefile"
-  [fstar.fst.config.json]="../_templates/fstar.fst.config.json"
-  [pal.config.json]="../_templates/pal.config.json"
-  [pal.h]="../pal.h"
-)
+EXPECTED="
+Makefile=../_templates/Makefile
+fstar.fst.config.json=../_templates/fstar.fst.config.json
+pal.config.json=../_templates/pal.config.json
+pal.h=../pal.h
+"
 
 status=0
 
 while IFS= read -r d; do
   name="$(basename "$d")"
-  for f in "${!EXPECTED[@]}"; do
-    expected="${EXPECTED[$f]}"
+  for pair in $EXPECTED; do
+    f="${pair%%=*}"
+    expected="${pair#*=}"
     path="$d/$f"
     if [ ! -L "$path" ]; then
       echo "ERROR: test/$name/$f is missing or not a symlink (expected symlink to $expected; see test/new.sh)" >&2


### PR DESCRIPTION
Hi, I've been using PAL in the past few weeks for translating some Linux kernel C code to Pulse.
I've fixed some bugs and extended some minor features along the way.

Thought it would be useful to upstream some of them.

Fixed three issues causing `make test` to fail on macOS:

- The clang driver used through libclang does not run the `xcrun` SDK lookup the command-line driver performs, so every `#include <stdlib.h>` failed with "file not found".

- Apple's fortified libc headers rewrite `memset` (and others) into `__builtin___memset_chk`, which the translator does not model. Fixed by passing `-D_FORTIFY_SOURCE=0`.

- `test/check-template.sh` used bash-4 associative arrays; macOS by default ships bash 3.2, where `declare -A` fails. Rewritten with plain name=target pairs.